### PR TITLE
CIのユニットテストの実行をリファクタ

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -19,4 +19,4 @@ jobs:
       - run: npm i -g pnpm
       - run: pnpm install
       - run: pnpm lint
-      - run: pnpm test renderer/src
+      - run: pnpm test

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "prepare": "husky install",
     "format": "prettier --write \"**/*.{js,ts,tsx,json}\"",
     "test:jest": "jest",
-    "test:coverage": "jest --coverage",
     "test": "pnpm test:jest"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "format": "prettier --write \"**/*.{js,ts,tsx,json}\"",
     "test:jest": "jest",
     "test:coverage": "jest --coverage",
-    "test": "pnpm run test:jest --"
+    "test": "pnpm test:jest"
   },
   "dependencies": {
     "jotai": "^1.1.3",


### PR DESCRIPTION
## 問題
`electron/` 配下のテストファイルをCIのユニットテスト実行に含まれていなかった

## やったこと
- testコマンドとCIをリファクタして全てのテストファイルが実行されるように修正
- test:coverage コマンドは不要なので削除
- CIのテストコマンドに渡していた引数を削除

## 補足
`HelloWorld` のテストは、まだコンポーネントのテストが存在しないので、サンプルコードとして残してあります。
コンポーネントのテストを書くタイミングで一緒に削除してください。