### PR TITLE
React18 を使えるように調整

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "dependencies": {
     "jotai": "^1.1.3",
     "node-fetch": "^2.6.1",
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0"
+    "react": "^18.0.0-alpha-d5de45820-20210714",
+    "react-dom": "^18.0.0-alpha-d5de45820-20210714"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.14.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ specifiers:
   lint-staged: ^11.0.0
   node-fetch: ^2.6.1
   prettier: ^2.3.2
-  react: ^17.0.0
-  react-dom: ^17.0.0
+  react: ^18.0.0-alpha-d5de45820-20210714
+  react-dom: ^18.0.0-alpha-d5de45820-20210714
   react-test-renderer: ^17.0.2
   rimraf: ^3.0.2
   ts-jest: ^27.0.3
@@ -34,14 +34,14 @@ specifiers:
   vite: ^2.3.5
 
 dependencies:
-  jotai: 1.1.3_react@17.0.2
+  jotai: 1.1.3_0681c0255aa41acb25a82827b152efd6
   node-fetch: 2.6.1
-  react: 17.0.2
-  react-dom: 17.0.2_react@17.0.2
+  react: 18.0.0-alpha-d5de45820-20210714
+  react-dom: 18.0.0-alpha-d5de45820-20210714_0681c0255aa41acb25a82827b152efd6
 
 devDependencies:
   '@testing-library/jest-dom': 5.14.1
-  '@testing-library/react': 12.0.0_react-dom@17.0.2+react@17.0.2
+  '@testing-library/react': 12.0.0_eece9722472c0ae8189ab3d703c22d26
   '@types/jest': 26.0.23
   '@types/node': 16.0.0
   '@types/node-fetch': 2.5.11
@@ -62,7 +62,7 @@ devDependencies:
   jest: 27.0.6
   lint-staged: 11.0.0
   prettier: 2.3.2
-  react-test-renderer: 17.0.2_react@17.0.2
+  react-test-renderer: 17.0.2_0681c0255aa41acb25a82827b152efd6
   rimraf: 3.0.2
   ts-jest: 27.0.3_c1e0131ba2fe0821c3a9f65b91a2cd6a
   typescript: 4.4.0-beta
@@ -848,7 +848,7 @@ packages:
       redent: 3.0.0
     dev: true
 
-  /@testing-library/react/12.0.0_react-dom@17.0.2+react@17.0.2:
+  /@testing-library/react/12.0.0_eece9722472c0ae8189ab3d703c22d26:
     resolution: {integrity: sha512-sh3jhFgEshFyJ/0IxGltRhwZv2kFKfJ3fN1vTZ6hhMXzz9ZbbcTgmDYM4e+zJv+oiVKKEWZPyqPAh4MQBI65gA==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -857,8 +857,8 @@ packages:
     dependencies:
       '@babel/runtime': 7.14.6
       '@testing-library/dom': 8.1.0
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
+      react: 18.0.0-alpha-d5de45820-20210714
+      react-dom: 18.0.0-alpha-d5de45820-20210714_0681c0255aa41acb25a82827b152efd6
     dev: true
 
   /@tootallnate/once/1.1.2:
@@ -3801,7 +3801,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /jotai/1.1.3_react@17.0.2:
+  /jotai/1.1.3_0681c0255aa41acb25a82827b152efd6:
     resolution: {integrity: sha512-7PZs8gHe8Y+7BkC6m32NbfeNGa8ybFMUoy2DbH542YVYrFEJPxqIE4Es/SXaII7f8r/UZGzg29XWNEDq+iCITg==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -3829,7 +3829,7 @@ packages:
       xstate:
         optional: true
     dependencies:
-      react: 17.0.2
+      react: 18.0.0-alpha-d5de45820-20210714
     dev: false
 
   /js-tokens/4.0.0:
@@ -4628,15 +4628,15 @@ packages:
       strip-json-comments: 2.0.1
     dev: true
 
-  /react-dom/17.0.2_react@17.0.2:
-    resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
+  /react-dom/18.0.0-alpha-d5de45820-20210714_0681c0255aa41acb25a82827b152efd6:
+    resolution: {integrity: sha512-6ZIlPQMxyFe6ovnpKT7HGe4gwm7eloJcx+cYhbzdq8mSTDNcLmVm3IPcvwaysWyXH6KbS83s2VmdYV90eFCpBQ==}
     peerDependencies:
-      react: 17.0.2
+      react: 18.0.0-alpha-d5de45820-20210714
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-      react: 17.0.2
-      scheduler: 0.20.2
+      react: 18.0.0-alpha-d5de45820-20210714
+      scheduler: 0.21.0-alpha-d5de45820-20210714
     dev: false
 
   /react-is/16.13.1:
@@ -4652,30 +4652,30 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /react-shallow-renderer/16.14.1_react@17.0.2:
+  /react-shallow-renderer/16.14.1_0681c0255aa41acb25a82827b152efd6:
     resolution: {integrity: sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==}
     peerDependencies:
       react: ^16.0.0 || ^17.0.0
     dependencies:
       object-assign: 4.1.1
-      react: 17.0.2
+      react: 18.0.0-alpha-d5de45820-20210714
       react-is: 17.0.2
     dev: true
 
-  /react-test-renderer/17.0.2_react@17.0.2:
+  /react-test-renderer/17.0.2_0681c0255aa41acb25a82827b152efd6:
     resolution: {integrity: sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==}
     peerDependencies:
       react: 17.0.2
     dependencies:
       object-assign: 4.1.1
-      react: 17.0.2
+      react: 18.0.0-alpha-d5de45820-20210714
       react-is: 17.0.2
-      react-shallow-renderer: 16.14.1_react@17.0.2
+      react-shallow-renderer: 16.14.1_0681c0255aa41acb25a82827b152efd6
       scheduler: 0.20.2
     dev: true
 
-  /react/17.0.2:
-    resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
+  /react/18.0.0-alpha-d5de45820-20210714:
+    resolution: {integrity: sha512-oXiT7EUNy63LXR2xYBL9IZlnxk5BVf7IWEQZ7Ek0y/dHr2x4oPahpm+MfzlctloztPmRFPVAQncrI6Xy4iQmdA==}
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
@@ -4875,6 +4875,14 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
+    dev: true
+
+  /scheduler/0.21.0-alpha-d5de45820-20210714:
+    resolution: {integrity: sha512-wVd2aFWJlcIySCLmR4+sRr2EdcLt8IxgLTcOggzwSvVVI73hnhPqc5falHM/s6qMrXKKKnsa72Gl6Ovqohc3Zw==}
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+    dev: false
 
   /semver-compare/1.0.0:
     resolution: {integrity: sha1-De4hahyUGrN+nvsXiPavxf9VN/w=}

--- a/renderer/src/main.tsx
+++ b/renderer/src/main.tsx
@@ -4,7 +4,9 @@ import './index.css';
 import App from './App';
 
 const rootElement = document.getElementById('root');
+
 if (!rootElement) throw new Error('Failed to find the root element');
+
 const root = ReactDOM.createRoot(rootElement);
 
 root.render(

--- a/renderer/src/main.tsx
+++ b/renderer/src/main.tsx
@@ -3,9 +3,12 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 
-ReactDOM.render(
+const rootElement = document.getElementById('root');
+if (!rootElement) throw new Error('Failed to find the root element');
+const root = ReactDOM.createRoot(rootElement);
+
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  document.getElementById('root')
+  </React.StrictMode>
 );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,15 @@
     "jsx": "react-jsx",
     "useUnknownInCatchVariables": true,
     "exactOptionalPropertyTypes": true,
-    "baseUrl": "."
+    "baseUrl": ".",
+    "types": [
+      "jest",
+      "node",
+      "node-fetch",
+      "react/next",
+      "react-dom/next",
+      "testing-library__jest-dom"
+    ]
   },
   "include": ["./renderer"]
 }


### PR DESCRIPTION
React18 (alpha) を使用できるように調整

注意点が2つあります。

1つめはテストで  `@testing-library/react` の `render` を使用していますが、React18 では `createRoot` に変更されているようで、テストを実行すると error (内容は warning) が表示されます。
テスト自体は通ります。
ref: https://github.com/reactwg/react-18/discussions/5

もう1つは React18 の型定義を使用する方法が tsconfig.json の types で直接指定するしかなく、今後 `pnpm install -D @types/foo`  で追加する型定義は手動で types に追加していくことになります。