### PR TITLE
保護ブランチへ直接プッシュするのを禁止

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+. "$(dirname "$0")/scripts/prevent-push.sh"

--- a/.husky/scripts/prevent-push.sh
+++ b/.husky/scripts/prevent-push.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# 保護ブランチへ直接プッシュすることを禁止する
+
+current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+protected_branch='main'
+policy="\033[31m[Policy] Never push code directly to the "$protected_branch" branch! (Prevented with pre-push hook.)\033[m\n"
+
+exit_fail() {
+  echo $policy
+  exit 1
+}
+
+if [ $current_branch = $protected_branch ]; then
+  exit_fail
+fi


### PR DESCRIPTION
## やったこと
- 保護ブランチへ直接プッシュするのを禁止する git-hooks を追加
  - pre-push フックで main ブランチへプッシュをするとエラーでプッシュがキャンセルされます

## 実行の様子
```
ヾ(*・ω・)ノ ~/workspace/review-cat  [ main ]
$ git push origin master
[Policy] Never push code directly to the main branch! (Prevented with pre-push hook.)

husky - pre-push hook exited with code 1 (error)
error: failed to push some refs to 'https://github.com/higeOhige/review-cat.git'
```