### PR TITLE
ルーティングの基盤実装

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,6 @@
   "rules": {
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
-    "react/react-in-jsx-scope": "off",
     "react/display-name": "off"
   },
   "overrides": [
@@ -30,7 +29,8 @@
       "files": ["*.ts", "*.tsx"],
       "extends": ["plugin:@typescript-eslint/recommended"],
       "rules": {
-        "@typescript-eslint/explicit-module-boundary-types": "off"
+        "@typescript-eslint/explicit-module-boundary-types": "off",
+        "react/prop-types": "off"
       }
     }
   ]

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-relay": "^11.0.2",
+    "react-router-dom": "^5.2.0",
     "relay-runtime": "^11.0.2"
   },
   "devDependencies": {
@@ -41,6 +42,7 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@types/react-relay": "^11.0.2",
+    "@types/react-router-dom": "^5.1.8",
     "@types/relay-runtime": "^11.0.1",
     "@typescript-eslint/eslint-plugin": "^4.28.1",
     "@typescript-eslint/parser": "^4.28.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ specifiers:
   '@types/react': ^17.0.0
   '@types/react-dom': ^17.0.0
   '@types/react-relay': ^11.0.2
+  '@types/react-router-dom': ^5.1.8
   '@types/relay-runtime': ^11.0.1
   '@typescript-eslint/eslint-plugin': ^4.28.1
   '@typescript-eslint/parser': ^4.28.1
@@ -35,6 +36,7 @@ specifiers:
   react: ^17.0.2
   react-dom: ^17.0.2
   react-relay: ^11.0.2
+  react-router-dom: ^5.2.0
   react-test-renderer: ^17.0.2
   relay-compiler: ^11.0.2
   relay-compiler-language-typescript: ^14.0.0
@@ -54,6 +56,7 @@ dependencies:
   react: 17.0.2
   react-dom: 17.0.2_react@17.0.2
   react-relay: 11.0.2_react@17.0.2
+  react-router-dom: 5.2.0_react@17.0.2
   relay-runtime: 11.0.2
 
 devDependencies:
@@ -65,6 +68,7 @@ devDependencies:
   '@types/react': 17.0.13
   '@types/react-dom': 17.0.8
   '@types/react-relay': 11.0.2
+  '@types/react-router-dom': 5.1.8
   '@types/relay-runtime': 11.0.1
   '@typescript-eslint/eslint-plugin': 4.28.1_4bd1f664fc9e77a994e25b7feb1565b5
   '@typescript-eslint/parser': 4.28.1_c2b6312714409ad28228f03e877b2752
@@ -1252,6 +1256,10 @@ packages:
       '@types/node': 16.0.0
     dev: true
 
+  /@types/history/4.7.9:
+    resolution: {integrity: sha512-MUc6zSmU3tEVnkQ78q0peeEjKWPUADMlC/t++2bI8WnAG2tvYRPIgHG8lWkXwqc8MsUF6Z2MOf+Mh5sazOmhiQ==}
+    dev: true
+
   /@types/istanbul-lib-coverage/2.0.3:
     resolution: {integrity: sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==}
     dev: true
@@ -1349,6 +1357,21 @@ packages:
     dependencies:
       '@types/react': 17.0.14
       '@types/relay-runtime': 11.0.1
+    dev: true
+
+  /@types/react-router-dom/5.1.8:
+    resolution: {integrity: sha512-03xHyncBzG0PmDmf8pf3rehtjY0NpUj7TIN46FrT5n1ZWHPZvXz32gUyNboJ+xsL8cpg8bQVLcllptcQHvocrw==}
+    dependencies:
+      '@types/history': 4.7.9
+      '@types/react': 17.0.14
+      '@types/react-router': 5.1.16
+    dev: true
+
+  /@types/react-router/5.1.16:
+    resolution: {integrity: sha512-8d7nR/fNSqlTFGHti0R3F9WwIertOaaA1UEB8/jr5l5mDMOs4CidEgvvYMw4ivqrBK+vtVLxyTj2P+Pr/dtgzg==}
+    dependencies:
+      '@types/history': 4.7.9
+      '@types/react': 17.0.14
     dev: true
 
   /@types/react/17.0.13:
@@ -3478,6 +3501,23 @@ packages:
       function-bind: 1.1.1
     dev: true
 
+  /history/4.10.1:
+    resolution: {integrity: sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==}
+    dependencies:
+      '@babel/runtime': 7.14.6
+      loose-envify: 1.4.0
+      resolve-pathname: 3.0.0
+      tiny-invariant: 1.1.0
+      tiny-warning: 1.0.3
+      value-equal: 1.0.1
+    dev: false
+
+  /hoist-non-react-statics/3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+    dependencies:
+      react-is: 16.13.1
+    dev: false
+
   /hosted-git-info/4.0.2:
     resolution: {integrity: sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==}
     engines: {node: '>=10'}
@@ -3813,6 +3853,10 @@ packages:
   /is-yarn-global/0.3.0:
     resolution: {integrity: sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==}
     dev: true
+
+  /isarray/0.0.1:
+    resolution: {integrity: sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=}
+    dev: false
 
   /isarray/1.0.0:
     resolution: {integrity: sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=}
@@ -4770,6 +4814,18 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /mini-create-react-context/0.4.1_prop-types@15.7.2+react@17.0.2:
+    resolution: {integrity: sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==}
+    peerDependencies:
+      prop-types: ^15.0.0
+      react: ^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@babel/runtime': 7.14.6
+      prop-types: 15.7.2
+      react: 17.0.2
+      tiny-warning: 1.0.3
+    dev: false
+
   /minimatch/3.0.4:
     resolution: {integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==}
     dependencies:
@@ -5054,6 +5110,12 @@ packages:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
     dev: true
 
+  /path-to-regexp/1.8.0:
+    resolution: {integrity: sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==}
+    dependencies:
+      isarray: 0.0.1
+    dev: false
+
   /path-type/4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -5182,7 +5244,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-    dev: true
 
   /proto-list/1.2.4:
     resolution: {integrity: sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=}
@@ -5239,7 +5300,6 @@ packages:
 
   /react-is/16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-    dev: true
 
   /react-is/17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -5261,6 +5321,39 @@ packages:
       nullthrows: 1.1.1
       react: 17.0.2
       relay-runtime: 11.0.2
+    dev: false
+
+  /react-router-dom/5.2.0_react@17.0.2:
+    resolution: {integrity: sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==}
+    peerDependencies:
+      react: '>=15'
+    dependencies:
+      '@babel/runtime': 7.14.6
+      history: 4.10.1
+      loose-envify: 1.4.0
+      prop-types: 15.7.2
+      react: 17.0.2
+      react-router: 5.2.0_react@17.0.2
+      tiny-invariant: 1.1.0
+      tiny-warning: 1.0.3
+    dev: false
+
+  /react-router/5.2.0_react@17.0.2:
+    resolution: {integrity: sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==}
+    peerDependencies:
+      react: '>=15'
+    dependencies:
+      '@babel/runtime': 7.14.6
+      history: 4.10.1
+      hoist-non-react-statics: 3.3.2
+      loose-envify: 1.4.0
+      mini-create-react-context: 0.4.1_prop-types@15.7.2+react@17.0.2
+      path-to-regexp: 1.8.0
+      prop-types: 15.7.2
+      react: 17.0.2
+      react-is: 16.13.1
+      tiny-invariant: 1.1.0
+      tiny-warning: 1.0.3
     dev: false
 
   /react-shallow-renderer/16.14.1_react@17.0.2:
@@ -5441,6 +5534,10 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
     dev: true
+
+  /resolve-pathname/3.0.0:
+    resolution: {integrity: sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==}
+    dev: false
 
   /resolve/1.20.0:
     resolution: {integrity: sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==}
@@ -5930,6 +6027,14 @@ packages:
     resolution: {integrity: sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=}
     dev: true
 
+  /tiny-invariant/1.1.0:
+    resolution: {integrity: sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==}
+    dev: false
+
+  /tiny-warning/1.0.3:
+    resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
+    dev: false
+
   /tmp-promise/3.0.2:
     resolution: {integrity: sha512-OyCLAKU1HzBjL6Ev3gxUeraJNlbNingmi8IrHHEsYH8LTmEuhvYfqvhn2F/je+mjf4N58UmZ96OMEy1JanSCpA==}
     dependencies:
@@ -6167,6 +6272,10 @@ packages:
       convert-source-map: 1.8.0
       source-map: 0.7.3
     dev: true
+
+  /value-equal/1.0.1:
+    resolution: {integrity: sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==}
+    dev: false
 
   /verror/1.10.0:
     resolution: {integrity: sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=}

--- a/renderer/src/App.tsx
+++ b/renderer/src/App.tsx
@@ -1,35 +1,14 @@
-import React, { Suspense } from 'react';
-import { Provider, useAtom } from 'jotai';
+import React from 'react';
+import { Provider } from 'jotai';
 import { RelayEnvironmentProvider } from 'react-relay/hooks';
-import { LoginPage, PullRequestListPage } from './pages';
 import RelayEnvironment from './graphql/relay/RelayEnvironment';
-import { isLoggedInAtom } from './jotai';
-
-// TODO: 別コンポーネントファイルに分割する
-//       リファクタ
-// TODO: react-router でルーティングする
-const AppRoute = () => {
-  const [isLoggedIn] = useAtom(isLoggedInAtom);
-
-  return isLoggedIn != null ? (
-    // TODO: Suspenseを削除するリファクタを実施
-    <Suspense fallback="Loading...">
-      <PullRequestListPage />
-    </Suspense>
-  ) : (
-    <Suspense fallback="Loading...">
-      <LoginPage />
-    </Suspense>
-  );
-};
+import { AppRoute } from './components/routes/AppRoute/AppRoute';
 
 const App = () => {
   return (
     <RelayEnvironmentProvider environment={RelayEnvironment}>
       <Provider>
-        <div className="App">
-          <AppRoute />
-        </div>
+        <AppRoute />
       </Provider>
     </RelayEnvironmentProvider>
   );

--- a/renderer/src/App.tsx
+++ b/renderer/src/App.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Provider } from 'jotai';
 import { RelayEnvironmentProvider } from 'react-relay/hooks';
 import RelayEnvironment from './graphql/relay/RelayEnvironment';
-import { AppRoute } from './components/routes/AppRoute/AppRoute';
+import { AppRoute } from './components/routes';
 
 const App = () => {
   return (

--- a/renderer/src/components/AuthProvider/AuthProvider.tsx
+++ b/renderer/src/components/AuthProvider/AuthProvider.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useAtom } from 'jotai';
+import { FC, Fragment, ReactNode, useEffect } from 'react';
+import { loginUserAtom } from '../../jotai';
+
+type AuthProviderProps = {
+  children: ReactNode;
+};
+
+export const AuthProvider: FC<AuthProviderProps> = ({ children }) => {
+  const [user, autoSignIn] = useAtom(loginUserAtom);
+
+  useEffect(() => {
+    if (user == null) {
+      autoSignIn();
+    }
+  }, [user, autoSignIn]);
+
+  return <Fragment>{children}</Fragment>;
+};

--- a/renderer/src/components/AuthProvider/index.ts
+++ b/renderer/src/components/AuthProvider/index.ts
@@ -1,0 +1,1 @@
+export * from './AuthProvider';

--- a/renderer/src/components/LoginButton/LoginButton.tsx
+++ b/renderer/src/components/LoginButton/LoginButton.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import { themeFocusVisibleOutline } from '../../theme.css';
 import { buttonStyle } from './styles.css';
-import { useAtom } from 'jotai';
-import { signInAtom } from '../../jotai/auth';
 
-export const LoginButton: React.FC = () => {
-  const [, signIn] = useAtom(signInAtom);
+type LoginButtonProps = {
+  onClick: () => void;
+};
 
+export const LoginButton: React.FC<LoginButtonProps> = ({ onClick }) => {
   return (
     <button
       className={`${buttonStyle} ${themeFocusVisibleOutline}`}
       type="button"
-      onClick={signIn}
+      onClick={onClick}
     >
       Login To GitHub
     </button>

--- a/renderer/src/components/LoginContent/LoginContent.tsx
+++ b/renderer/src/components/LoginContent/LoginContent.tsx
@@ -6,15 +6,27 @@ import {
   iconContainerStyle,
   buttonContainerStyle,
 } from './styles.css';
+import { useAtom } from 'jotai';
+import { signInAtom } from '../../jotai/auth';
+import { useHistory } from 'react-router-dom';
 
 export const LoginContent: React.FC = () => {
+  const history = useHistory();
+  const [, signIn] = useAtom(signInAtom);
+
+  const handleClick = () => {
+    signIn(() => {
+      history.replace('/');
+    });
+  };
+
   return (
     <div className={`${rootStyle}`}>
       <div className={`${iconContainerStyle}`}>
         <AppIcon />
       </div>
       <div className={`${buttonContainerStyle}`}>
-        <LoginButton />
+        <LoginButton onClick={handleClick} />
       </div>
     </div>
   );

--- a/renderer/src/components/routes/AppRoute/AppRoute.tsx
+++ b/renderer/src/components/routes/AppRoute/AppRoute.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Route, BrowserRouter as Router, Switch } from 'react-router-dom';
+import { LoginPage, PullRequestListPage } from '../../../pages';
+import { PrivateRoute } from '../PrivateRoute/PrivateRoute';
+
+export const AppRoute = () => {
+  return (
+    <Router>
+      <Switch>
+        <Route path="/login">
+          <LoginPage />
+        </Route>
+        <PrivateRoute path="/">
+          <PullRequestListPage />
+        </PrivateRoute>
+      </Switch>
+    </Router>
+  );
+};

--- a/renderer/src/components/routes/AppRoute/AppRoute.tsx
+++ b/renderer/src/components/routes/AppRoute/AppRoute.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Route, BrowserRouter as Router, Switch } from 'react-router-dom';
 import { LoginPage, PullRequestListPage } from '../../../pages';
-import { PrivateRoute } from '../PrivateRoute/PrivateRoute';
+import { PrivateRoute } from '../PrivateRoute';
 
 export const AppRoute = () => {
   return (

--- a/renderer/src/components/routes/AppRoute/index.ts
+++ b/renderer/src/components/routes/AppRoute/index.ts
@@ -1,0 +1,1 @@
+export * from './AppRoute';

--- a/renderer/src/components/routes/PrivateRoute/PrivateRoute.tsx
+++ b/renderer/src/components/routes/PrivateRoute/PrivateRoute.tsx
@@ -2,7 +2,7 @@ import React, { FC, ReactNode, Suspense } from 'react';
 import { Route, RouteProps, Redirect } from 'react-router-dom';
 import { useAtom } from 'jotai';
 import { isLoggedInAtom } from '../../../jotai';
-import { AuthProvider } from '../../AuthProvider/AuthProvider';
+import { AuthProvider } from '../../AuthProvider';
 
 type PrivateRouteProps = RouteProps & {
   children?: ReactNode;

--- a/renderer/src/components/routes/PrivateRoute/PrivateRoute.tsx
+++ b/renderer/src/components/routes/PrivateRoute/PrivateRoute.tsx
@@ -1,0 +1,25 @@
+import React, { FC, ReactNode, Suspense } from 'react';
+import { Route, RouteProps, Redirect } from 'react-router-dom';
+import { useAtom } from 'jotai';
+import { isLoggedInAtom } from '../../../jotai';
+import { AuthProvider } from '../../AuthProvider/AuthProvider';
+
+type PrivateRouteProps = RouteProps & {
+  children?: ReactNode;
+};
+
+export const PrivateRoute: FC<PrivateRouteProps> = ({ children, ...rest }) => {
+  const [isLoggedIn] = useAtom(isLoggedInAtom);
+
+  return (
+    <Route {...rest}>
+      {isLoggedIn ? (
+        <Suspense fallback="Loading...">
+          <AuthProvider>{children}</AuthProvider>
+        </Suspense>
+      ) : (
+        <Redirect to="/login" />
+      )}
+    </Route>
+  );
+};

--- a/renderer/src/components/routes/PrivateRoute/index.ts
+++ b/renderer/src/components/routes/PrivateRoute/index.ts
@@ -1,0 +1,1 @@
+export * from './PrivateRoute';

--- a/renderer/src/components/routes/index.ts
+++ b/renderer/src/components/routes/index.ts
@@ -1,0 +1,2 @@
+export * from './PrivateRoute';
+export * from './AppRoute';

--- a/renderer/src/jotai/auth.ts
+++ b/renderer/src/jotai/auth.ts
@@ -16,8 +16,14 @@ export const tokenAtomWithPersistence = atom<string | null, string>(
   }
 );
 
-export const signInAtom = atom(null, async (get, set) => {
-  const code = await window.ipc.loginWithGithub();
-  const token = await window.ipc.getAccessToken(code);
-  set(tokenAtomWithPersistence, token);
-});
+export const signInAtom = atom<null, (() => void) | undefined>(
+  null,
+  async (get, set, callback) => {
+    const code = await window.ipc.loginWithGithub();
+    const token = await window.ipc.getAccessToken(code);
+    set(tokenAtomWithPersistence, token);
+    if (callback != null) {
+      callback();
+    }
+  }
+);

--- a/renderer/src/pages/LoginPage/LoginPage.tsx
+++ b/renderer/src/pages/LoginPage/LoginPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { BaseLayout } from '../../layouts/BaseLayout';
 import { LoginContent } from '../../components/LoginContent';
 import { contentContainerStyle } from './styles.css';
@@ -7,7 +7,9 @@ export const LoginPage = () => {
   return (
     <BaseLayout>
       <div className={`${contentContainerStyle}`}>
-        <LoginContent />
+        <Suspense fallback="Loading...">
+          <LoginContent />
+        </Suspense>
       </div>
     </BaseLayout>
   );

--- a/renderer/src/pages/PullRequestListPage/PullRequestListPage.tsx
+++ b/renderer/src/pages/PullRequestListPage/PullRequestListPage.tsx
@@ -1,5 +1,5 @@
 import { useAtom } from 'jotai';
-import React, { FC, Suspense, useEffect } from 'react';
+import React, { FC, Suspense } from 'react';
 import { loadQuery, useRelayEnvironment } from 'react-relay';
 import { PullRequestListContainer } from '../../containers/PullRequestListContainer/PullRequestListContainer';
 import { SearchPullRequestsQuery } from '../../graphql/queries';
@@ -11,33 +11,23 @@ export const PullRequestListPage: FC = () => {
   // TODO: ユーザー情報の取得周りは AppStateProvider, useAppState を作成してそちらに寄せる
   // ここでユーザー情報の更新をすると親コンポーネントで Suspense でラップする必要がありナビゲーション含めてフォールバックされる
   const environment = useRelayEnvironment();
-  const [user, autoSignIn] = useAtom(loginUserAtom);
-
-  useEffect(() => {
-    if (user == null) {
-      autoSignIn();
-    }
-  }, [user]);
+  const [user] = useAtom(loginUserAtom);
 
   // REFACTOR: user のnullチェックが不要な形に変更できない？
   return (
     <BaseLayout>
-      {user != null ? (
-        <Suspense fallback="Loading...">
-          <PullRequestListContainer
-            preloadedQuery={loadQuery(environment, SearchPullRequestsQuery, {
-              login_user_name: user.name,
-              // TODO: 購読するリポジトリの一覧を設定から取得
-              search_query: buildSearchPullRequestsQuery([
-                't-yng/blog',
-                'higeOhige/review-cat',
-              ]),
-            })}
-          />
-        </Suspense>
-      ) : (
-        <span>Loading...</span>
-      )}
+      <Suspense fallback="Loading...">
+        <PullRequestListContainer
+          preloadedQuery={loadQuery(environment, SearchPullRequestsQuery, {
+            login_user_name: user?.name ?? '',
+            // TODO: 購読するリポジトリの一覧を設定から取得
+            search_query: buildSearchPullRequestsQuery([
+              't-yng/blog',
+              'higeOhige/review-cat',
+            ]),
+          })}
+        />
+      </Suspense>
     </BaseLayout>
   );
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ESNext",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
-    "skipLibCheck": false,
+    "skipLibCheck": true, // @types/react がバージョン違いで Duplicate identifier が発生するので true に設定
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
     "strict": true,


### PR DESCRIPTION
# やったこと
- React Router の導入
- ルーティングの実装
- ユーザー情報を提供する AuthProvider の実装
- tsconfig の skipLibCheck を true に変更

# 検証
- [x] ログイン状態でアプリケーションを起動したときにPR一覧ページに遷移する
- [x] ログアウト状態（tokenが存在しない）でアプリケーションを起動するとログイン画面に遷移する
- [x] ログイン画面からログインに成功したときにPR一覧ページ遷移する

# 気になる点
AuthProvider を Suspense でラップする影響でユーザー情報の取得中にナビゲーションバーを含めたページ全体がロード表示になってします。
理想はナビゲーションは初期表示で表示したい。
原因は AuthProvider > Page Component > Layout > PageContent となっているのが原因なので、
Layout > AuthProvide > PageComponent とすれば実現は可能。今のデザインだと問題ないが、ページでレイアウトを変更するデザインになると厳しくなる。（現状はそのデザインになる予定はない。）

close #51 