### PR TITLE
設定情報をストレージに読み書きするカスタムhooksを実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",
+    "@testing-library/react-hooks": "^7.0.1",
     "@types/jest": "^26.0.24",
     "@types/node": "^16.0.0",
     "@types/node-fetch": "^2.5.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: 5.3
 specifiers:
   '@testing-library/jest-dom': ^5.14.1
   '@testing-library/react': ^12.0.0
+  '@testing-library/react-hooks': ^7.0.1
   '@types/jest': ^26.0.24
   '@types/node': ^16.0.0
   '@types/node-fetch': ^2.5.11
@@ -62,6 +63,7 @@ dependencies:
 devDependencies:
   '@testing-library/jest-dom': 5.14.1
   '@testing-library/react': 12.0.0_react-dom@17.0.2+react@17.0.2
+  '@testing-library/react-hooks': 7.0.1_fc2bb8a5b006d3f25c5f84ea777e678d
   '@types/jest': 26.0.24
   '@types/node': 16.0.0
   '@types/node-fetch': 2.5.11
@@ -748,6 +750,13 @@ packages:
     dependencies:
       regenerator-runtime: 0.13.7
 
+  /@babel/runtime/7.14.8:
+    resolution: {integrity: sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.13.9
+    dev: true
+
   /@babel/template/7.14.5:
     resolution: {integrity: sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==}
     engines: {node: '>=6.9.0'}
@@ -1181,6 +1190,29 @@ packages:
       redent: 3.0.0
     dev: true
 
+  /@testing-library/react-hooks/7.0.1_fc2bb8a5b006d3f25c5f84ea777e678d:
+    resolution: {integrity: sha512-bpEQ2SHSBSzBmfJ437NmnP+oArQ7aVmmULiAp6Ag2rtyLBLPNFSMmgltUbFGmQOJdPWo4Ub31kpUC5T46zXNwQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+      react-test-renderer: '>=16.9.0'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-test-renderer:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.14.8
+      '@types/react': 17.0.15
+      '@types/react-dom': 17.0.9
+      '@types/react-test-renderer': 17.0.1
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      react-error-boundary: 3.1.3_react@17.0.2
+      react-test-renderer: 17.0.2_react@17.0.2
+    dev: true
+
   /@testing-library/react/12.0.0_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-sh3jhFgEshFyJ/0IxGltRhwZv2kFKfJ3fN1vTZ6hhMXzz9ZbbcTgmDYM4e+zJv+oiVKKEWZPyqPAh4MQBI65gA==}
     engines: {node: '>=12'}
@@ -1352,6 +1384,12 @@ packages:
       '@types/react': 17.0.13
     dev: true
 
+  /@types/react-dom/17.0.9:
+    resolution: {integrity: sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==}
+    dependencies:
+      '@types/react': 17.0.15
+    dev: true
+
   /@types/react-relay/11.0.2:
     resolution: {integrity: sha512-g6lrdgvcjDKxUA4S3ZzZc/+Vtl5KOJPLgTTO2s20wKClV0Pws8OIkmuptMQkTucID4nozfrkVJo0D+xBff3Qmw==}
     dependencies:
@@ -1374,6 +1412,12 @@ packages:
       '@types/react': 17.0.14
     dev: true
 
+  /@types/react-test-renderer/17.0.1:
+    resolution: {integrity: sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==}
+    dependencies:
+      '@types/react': 17.0.15
+    dev: true
+
   /@types/react/17.0.13:
     resolution: {integrity: sha512-D/G3PiuqTfE3IMNjLn/DCp6umjVCSvtZTPdtAFy5+Ved6CsdRvivfKeCzw79W4AatShtU4nGqgvOv5Gro534vQ==}
     dependencies:
@@ -1384,6 +1428,14 @@ packages:
 
   /@types/react/17.0.14:
     resolution: {integrity: sha512-0WwKHUbWuQWOce61UexYuWTGuGY/8JvtUe/dtQ6lR4sZ3UiylHotJeWpf3ArP9+DSGUoLY3wbU59VyMrJps5VQ==}
+    dependencies:
+      '@types/prop-types': 15.7.4
+      '@types/scheduler': 0.16.2
+      csstype: 3.0.8
+    dev: true
+
+  /@types/react/17.0.15:
+    resolution: {integrity: sha512-uTKHDK9STXFHLaKv6IMnwp52fm0hwU+N89w/p9grdUqcFA6WuqDyPhaWopbNyE1k/VhgzmHl8pu1L4wITtmlLw==}
     dependencies:
       '@types/prop-types': 15.7.4
       '@types/scheduler': 0.16.2
@@ -5298,6 +5350,16 @@ packages:
       scheduler: 0.20.2
     dev: false
 
+  /react-error-boundary/3.1.3_react@17.0.2:
+    resolution: {integrity: sha512-A+F9HHy9fvt9t8SNDlonq01prnU8AmkjvGKV4kk8seB9kU3xMEO8J/PQlLVmoOIDODl5U2kufSBs4vrWIqhsAA==}
+    engines: {node: '>=10', npm: '>=6'}
+    peerDependencies:
+      react: '>=16.13.1'
+    dependencies:
+      '@babel/runtime': 7.14.8
+      react: 17.0.2
+    dev: true
+
   /react-is/16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -5419,6 +5481,10 @@ packages:
 
   /regenerator-runtime/0.13.7:
     resolution: {integrity: sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==}
+
+  /regenerator-runtime/0.13.9:
+    resolution: {integrity: sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==}
+    dev: true
 
   /regexp.prototype.flags/1.3.1:
     resolution: {integrity: sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==}

--- a/renderer/src/hooks/index.ts
+++ b/renderer/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './usePullRequests';
+export * from './useSettings';

--- a/renderer/src/hooks/useSettings.spec.ts
+++ b/renderer/src/hooks/useSettings.spec.ts
@@ -42,7 +42,7 @@ describe('useSettings', () => {
   });
 
   describe('updateSubscribedPRList', () => {
-    it('PRの監視するリポジトリの一覧が更新されること', () => {
+    it('PRを監視するリポジトリの一覧が更新されること', () => {
       const { result } = renderHook(() => useSettings());
 
       const prList = ['test/test1', 'test/test2'];

--- a/renderer/src/hooks/useSettings.spec.ts
+++ b/renderer/src/hooks/useSettings.spec.ts
@@ -1,19 +1,12 @@
-import React from 'react';
 import { renderHook, act } from '@testing-library/react-hooks';
-import { Provider } from 'jotai';
-import { FC } from 'react';
 import { useSettings } from './useSettings';
 
 jest.mock('../lib/storage');
 
 describe('useSettings', () => {
-  const wrapper: FC = ({ children }) => {
-    return <Provider>{children}</Provider>;
-  };
-
   describe('updateNotifyReviewRequested', () => {
     it('レビューリクエストの通知設定が更新されること', () => {
-      const { result } = renderHook(() => useSettings(), { wrapper });
+      const { result } = renderHook(() => useSettings());
 
       const updated = !result.current.settings.notifyReviewRequested;
       act(() => {
@@ -26,7 +19,7 @@ describe('useSettings', () => {
 
   describe('updateShowsPR', () => {
     it('PRの表示設定が更新されること', () => {
-      const { result } = renderHook(() => useSettings(), { wrapper });
+      const { result } = renderHook(() => useSettings());
       const settings = result.current.settings;
 
       const updatedRequestedReview = !settings.showsRequestedReviewPR;
@@ -50,7 +43,7 @@ describe('useSettings', () => {
 
   describe('updateSubscribedPRList', () => {
     it('PRの監視するリポジトリの一覧が更新されること', () => {
-      const { result } = renderHook(() => useSettings(), { wrapper });
+      const { result } = renderHook(() => useSettings());
 
       const prList = ['test/test1', 'test/test2'];
       act(() => {

--- a/renderer/src/hooks/useSettings.spec.tsx
+++ b/renderer/src/hooks/useSettings.spec.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react-hooks';
+import { Provider } from 'jotai';
+import { FC } from 'react';
+import { useSettings } from './useSettings';
+
+jest.mock('../lib/storage');
+
+describe('useSettings', () => {
+  const wrapper: FC = ({ children }) => {
+    return <Provider>{children}</Provider>;
+  };
+
+  describe('updateNotifyReviewRequested', () => {
+    it('レビューリクエストの通知設定が更新されること', () => {
+      const { result } = renderHook(() => useSettings(), { wrapper });
+
+      const updated = !result.current.settings.notifyReviewRequested;
+      act(() => {
+        result.current.updateNotifyReviewRequested(updated);
+      });
+
+      expect(result.current.settings.notifyReviewRequested).toBe(updated);
+    });
+  });
+
+  describe('updateShowsPR', () => {
+    it('PRの表示設定が更新されること', () => {
+      const { result } = renderHook(() => useSettings(), { wrapper });
+      const settings = result.current.settings;
+
+      const updatedRequestedReview = !settings.showsRequestedReviewPR;
+      const updatedInReview = !settings.showsInReviewPR;
+      const updatedApproved = !settings.showsApprovedPR;
+      act(() => {
+        result.current.updateShowsPR({
+          requestedReview: updatedRequestedReview,
+          inReview: updatedInReview,
+          approved: updatedApproved,
+        });
+      });
+
+      expect(result.current.settings.showsRequestedReviewPR).toBe(
+        updatedRequestedReview
+      );
+      expect(result.current.settings.showsInReviewPR).toBe(updatedInReview);
+      expect(result.current.settings.showsApprovedPR).toBe(updatedApproved);
+    });
+  });
+
+  describe('updateSubscribedPRList', () => {
+    it('PRの監視するリポジトリの一覧が更新されること', () => {
+      const { result } = renderHook(() => useSettings(), { wrapper });
+
+      const prList = ['test/test1', 'test/test2'];
+      act(() => {
+        result.current.updateSubscribedPRList(prList);
+      });
+
+      expect(result.current.settings.subscribedPRList).toEqual(prList);
+    });
+  });
+});

--- a/renderer/src/hooks/useSettings.ts
+++ b/renderer/src/hooks/useSettings.ts
@@ -1,0 +1,60 @@
+import { useAtom } from 'jotai';
+import { useCallback } from 'react';
+import { settingsReducerAtom, UPDATE_ACTION } from '../jotai/settings';
+
+export const useSettings = () => {
+  const [settings, dispatch] = useAtom(settingsReducerAtom);
+
+  const updateNotifyReviewRequested = useCallback(
+    (notifyReviewRequested: boolean) => {
+      dispatch({
+        type: UPDATE_ACTION,
+        payload: {
+          notifyReviewRequested,
+        },
+      });
+    },
+    [dispatch]
+  );
+
+  const updateShowsPR = useCallback(
+    ({
+      requestedReview,
+      inReview,
+      approved,
+    }: {
+      requestedReview: boolean;
+      inReview: boolean;
+      approved: boolean;
+    }) => {
+      dispatch({
+        type: UPDATE_ACTION,
+        payload: {
+          showsRequestedReviewPR: requestedReview,
+          showsInReviewPR: inReview,
+          showsApprovedPR: approved,
+        },
+      });
+    },
+    [dispatch]
+  );
+
+  const updateSubscribedPRList = useCallback(
+    (prList: string[]) => {
+      dispatch({
+        type: UPDATE_ACTION,
+        payload: {
+          subscribedPRList: prList,
+        },
+      });
+    },
+    [dispatch]
+  );
+
+  return {
+    settings,
+    updateNotifyReviewRequested,
+    updateShowsPR,
+    updateSubscribedPRList,
+  };
+};

--- a/renderer/src/jotai/index.ts
+++ b/renderer/src/jotai/index.ts
@@ -1,2 +1,3 @@
 export * from './auth';
 export * from './user';
+export * from './settings';

--- a/renderer/src/jotai/settings.spec.ts
+++ b/renderer/src/jotai/settings.spec.ts
@@ -1,0 +1,60 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useAtom } from 'jotai';
+import { Settings } from '../models';
+import { settingsReducerAtom, UPDATE_ACTION } from './settings';
+import { storage } from '../lib/storage';
+
+jest.mock('../lib/storage');
+const mockStorage = storage as jest.Mocked<typeof storage>;
+
+describe('jotai/settings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('update settings', () => {
+    it('設定情報を更新する時にストレージに更新後の設定情報が保存されること', () => {
+      const { result } = renderHook(() => useAtom(settingsReducerAtom));
+
+      const updated: Settings = {
+        notifyReviewRequested: true,
+        showsRequestedReviewPR: true,
+        showsInReviewPR: true,
+        showsApprovedPR: false,
+        subscribedPRList: ['test/test1', 'test/test2'],
+      };
+      act(() => {
+        result.current[1]({
+          type: UPDATE_ACTION,
+          payload: updated,
+        });
+      });
+
+      expect(mockStorage.setSettings).toBeCalledWith(updated);
+    });
+  });
+
+  describe('initial settings', () => {
+    it('ストレージから設定情報を読み込むこと', () => {
+      const savedSettings: Settings = {
+        notifyReviewRequested: true,
+        showsRequestedReviewPR: true,
+        showsInReviewPR: true,
+        showsApprovedPR: false,
+        subscribedPRList: ['test/test1', 'test/test2'],
+      };
+      mockStorage.getSettings.mockReturnValue(savedSettings);
+
+      const { result } = renderHook(() => useAtom(settingsReducerAtom));
+
+      expect(result.current[0]).toEqual(savedSettings);
+    });
+
+    it('ストレージに設定情報が存在しないときにデフォルトの値を初期値として返すこと', () => {
+      mockStorage.getSettings.mockReturnValue(null);
+      const { result } = renderHook(() => useAtom(settingsReducerAtom));
+
+      expect(result.current[0]).not.toBeNull();
+    });
+  });
+});

--- a/renderer/src/jotai/settings.ts
+++ b/renderer/src/jotai/settings.ts
@@ -1,0 +1,40 @@
+import { atomWithReducer } from 'jotai/utils';
+import { storage } from '../lib/storage';
+import { Settings } from '../models';
+
+export const UPDATE_ACTION = 'update' as const;
+
+type UpdateAction = {
+  type: typeof UPDATE_ACTION;
+  payload: Partial<Settings>;
+};
+
+type SettingsAction = UpdateAction;
+
+const defaultSettings: Settings = {
+  notifyReviewRequested: false,
+  showsRequestedReviewPR: true,
+  showsInReviewPR: true,
+  showsApprovedPR: true,
+  subscribedPRList: [],
+};
+
+const initialSettings = storage.getSettings() ?? defaultSettings;
+
+const settingsReducer = (prev: Settings, action: SettingsAction) => {
+  switch (action.type) {
+    case UPDATE_ACTION: {
+      const newSettings: Settings = {
+        ...prev,
+        ...action.payload,
+      };
+      storage.setSettings(newSettings);
+      return newSettings;
+    }
+  }
+};
+
+export const settingsReducerAtom = atomWithReducer(
+  initialSettings,
+  settingsReducer
+);

--- a/renderer/src/lib/storage.spec.ts
+++ b/renderer/src/lib/storage.spec.ts
@@ -50,7 +50,7 @@ describe('lib/storage', () => {
     });
 
     describe('setGithubAccessToken', () => {
-      it('localStorageからアクセストークンがセットできること', () => {
+      it('localStorageにアクセストークンがセットできること', () => {
         const token = 'token';
         const mockSetItem = mockLocalStorageSetItem();
 
@@ -84,7 +84,7 @@ describe('lib/storage', () => {
     });
 
     describe('setSettings', () => {
-      it('localStorageからアクセストークンがセットできること', () => {
+      it('localStorageに設定情報をセットできること', () => {
         const mockSetItem = mockLocalStorageSetItem();
 
         storage.setSettings(settings);

--- a/renderer/src/lib/storage.spec.ts
+++ b/renderer/src/lib/storage.spec.ts
@@ -1,7 +1,36 @@
+import { Settings } from '../models';
 import { storage } from './storage';
 
 describe('lib/storage', () => {
   const originalLocalStorage = window.localStorage;
+
+  const mockLocalStorageGetItem = (key: string, value: string | null) => {
+    const mockGetItem = jest.fn().mockImplementation((storageKey) => {
+      if (storageKey === key) {
+        return value;
+      } else {
+        null;
+      }
+    });
+
+    Object.defineProperty(window, 'localStorage', {
+      get: () => ({
+        getItem: mockGetItem,
+      }),
+    });
+  };
+
+  const mockLocalStorageSetItem = () => {
+    const mockSetItem = jest.fn();
+
+    Object.defineProperty(window, 'localStorage', {
+      get: () => ({
+        setItem: mockSetItem,
+      }),
+    });
+
+    return mockSetItem;
+  };
 
   afterAll(() => {
     Object.defineProperty(window, 'localStorage', {
@@ -9,41 +38,61 @@ describe('lib/storage', () => {
     });
   });
 
-  describe('getGithubAccessToken', () => {
-    it('localStorageからアクセストークンが取得できること', () => {
-      const token = 'token';
-      const mockGetItem = jest.fn().mockImplementation((key) => {
-        if (key === 'gh_atk') {
-          return token;
-        } else {
-          null;
-        }
-      });
+  describe('GithubAccessToken', () => {
+    describe('getGithubAccessToken', () => {
+      it('localStorageからアクセストークンが取得できること', () => {
+        const token = 'token';
+        mockLocalStorageGetItem('gh_atk', token);
 
-      Object.defineProperty(window, 'localStorage', {
-        get: () => ({
-          getItem: mockGetItem,
-        }),
+        const result = storage.getGithubAccessToken();
+        expect(result).toBe(token);
       });
+    });
 
-      const result = storage.getGithubAccessToken();
-      expect(result).toBe(token);
+    describe('setGithubAccessToken', () => {
+      it('localStorageからアクセストークンがセットできること', () => {
+        const token = 'token';
+        const mockSetItem = mockLocalStorageSetItem();
+
+        storage.setGithubAccessToken(token);
+        expect(mockSetItem).toBeCalledWith('gh_atk', token);
+      });
     });
   });
 
-  describe('setGithubAccessToken', () => {
-    it('localStorageからアクセストークンがセットできること', () => {
-      const token = 'token';
-      const mockSetItem = jest.fn();
+  describe('Settings', () => {
+    const settings: Settings = {
+      notifyReviewRequested: false,
+      showsRequestedReviewPR: true,
+      showsInReviewPR: true,
+      showsApprovedPR: true,
+      subscribedPRList: ['test/test'],
+    };
 
-      Object.defineProperty(window, 'localStorage', {
-        get: () => ({
-          setItem: mockSetItem,
-        }),
+    describe('getSettings', () => {
+      it('localStorageから設定情報が取得できること', () => {
+        mockLocalStorageGetItem('settings', JSON.stringify(settings));
+        const result = storage.getSettings();
+        expect(result).toEqual(settings);
       });
 
-      storage.setGithubAccessToken(token);
-      expect(mockSetItem).toBeCalledWith('gh_atk', token);
+      it('値が存在しないときに null を返すこと', () => {
+        mockLocalStorageGetItem('settings', null);
+        const result = storage.getSettings();
+        expect(result).toBeNull();
+      });
+    });
+
+    describe('setSettings', () => {
+      it('localStorageからアクセストークンがセットできること', () => {
+        const mockSetItem = mockLocalStorageSetItem();
+
+        storage.setSettings(settings);
+        expect(mockSetItem).toBeCalledWith(
+          'settings',
+          JSON.stringify(settings) // NOTE: stringifyは順番が保証されないのでテストがコケる可能性があります。
+        );
+      });
     });
   });
 });

--- a/renderer/src/lib/storage.ts
+++ b/renderer/src/lib/storage.ts
@@ -1,4 +1,7 @@
+import { Settings } from '../models';
+
 const GITHUB_ACCESS_TOKEN_KEY = 'gh_atk';
+const SETTINGS_KEY = 'settings';
 
 const getGithubAccessToken = () =>
   localStorage.getItem(GITHUB_ACCESS_TOKEN_KEY);
@@ -6,7 +9,22 @@ const getGithubAccessToken = () =>
 const setGithubAccessToken = (token: string) =>
   localStorage.setItem(GITHUB_ACCESS_TOKEN_KEY, token);
 
+const getSettings = (): Settings | null => {
+  const settingsJson = localStorage.getItem(SETTINGS_KEY);
+  if (settingsJson == null) {
+    return null;
+  } else {
+    return JSON.parse(settingsJson);
+  }
+};
+
+const setSettings = (settings: Settings) => {
+  localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+};
+
 export const storage = {
   getGithubAccessToken,
   setGithubAccessToken,
+  getSettings,
+  setSettings,
 };

--- a/renderer/src/models/Settings.ts
+++ b/renderer/src/models/Settings.ts
@@ -1,0 +1,7 @@
+export interface Settings {
+  notifyReviewRequested: boolean;
+  showsRequestedReviewPR: boolean;
+  showsInReviewPR: boolean;
+  showsApprovedPR: boolean;
+  subscribedPRList: string[];
+}

--- a/renderer/src/models/index.ts
+++ b/renderer/src/models/index.ts
@@ -1,2 +1,3 @@
 export * from './PullRequest';
 export * from './User';
+export * from './Settings';


### PR DESCRIPTION
## やったこと
- storageモジュール設定情報をローカルストレージに保存・読み込む処理を追加
- 設定情報を管理する atom を実装
- コンポーネントから設定情報を更新、読み取るカスタムhooksを実装
- ユニットテストの記述

## レビュー
- カスタムhooksのインターフェースについて、こちらの方が良いなどあればご指摘をお願いします。🏄‍♂️

close #57 