### PR TITLE
typecheckのコマンドを修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:jest": "jest",
     "test": "pnpm test:jest",
     "relay": "relay-compiler",
-    "type-check": "pnpm type-check:renderer & pnpm type-check:electron",
+    "type-check": "pnpm type-check:renderer && pnpm type-check:electron",
     "type-check:renderer": "tsc --noEmit",
     "type-check:electron": "tsc -p tsconfig.electron.json --noEmit"
   },


### PR DESCRIPTION
型チェックを並列で動かすとローカル実行時に型エラーがあると結果の表示がバグっていたので、直列実行に変更