### PR TITLE
feature: 所属する組織アカウント一覧を取得する実装を追加

### DIFF
--- a/electron/src/constants/auth.ts
+++ b/electron/src/constants/auth.ts
@@ -7,5 +7,5 @@ export type OAuthOptions = {
 export const oAuthOptions = {
   clientId: process.env.GITHUB_APP_CLIENT_ID as string,
   clientSecret: process.env.GITHUB_APP_CLIENT_SECRET as string,
-  scopes: ['repo'],
+  scopes: ['repo', 'read:org'],
 };

--- a/renderer/src/components/SearchRepository/SearchRepository.tsx
+++ b/renderer/src/components/SearchRepository/SearchRepository.tsx
@@ -1,23 +1,52 @@
 import React, { memo, useEffect } from 'react';
 import { useCallback, useState, FC } from 'react';
-import { AccountSelect, RepositorySearchBox } from '..';
+import { useRelayEnvironment, fetchQuery } from 'react-relay';
+import { graphql } from 'relay-runtime';
+import { AccountSelect, RepositorySearchBox } from '../';
 import { searchRepositories } from '../../lib/searchRepositories';
 import { rootStyle } from './style.css';
+import type { SearchRepositoryAccountsQuery as SearchRepositoryAccountsQueryType } from './__generated__/SearchRepositoryAccountsQuery.graphql';
 
 type SearchRepositoryProps = {
   onSearch: (repositories: string[]) => void;
 };
 
+export const SearchRepositoryAccountsQuery = graphql`
+  query SearchRepositoryAccountsQuery {
+    viewer {
+      login
+      organizations(first: 20) {
+        nodes {
+          avatarUrl
+          login
+        }
+      }
+    }
+  }
+`;
+
 export const SearchRepository: FC<SearchRepositoryProps> = memo(
   ({ onSearch }) => {
+    const environment = useRelayEnvironment();
     const [account, setAccount] = useState<string | null>(null);
     const [accounts, setAccounts] = useState<string[]>([]);
 
     useEffect(() => {
-      // TODO: サクッとアカウントの一覧をAPIで取得する
-      const accounts = ['higeOhige', 'test1', 'test2'];
-      setAccounts(accounts);
-    }, []);
+      fetchQuery<SearchRepositoryAccountsQueryType>(
+        environment,
+        SearchRepositoryAccountsQuery,
+        {}
+      ).subscribe({
+        next: (data) => {
+          const nodes = data.viewer.organizations.nodes;
+          if (nodes == null) return;
+          const accounts = nodes
+            .map((node) => node?.login)
+            .filter((org) => org != null) as string[];
+          setAccounts([data.viewer.login, ...accounts]);
+        },
+      });
+    }, [environment]);
 
     const handleSearch = useCallback(
       async (keyword: string) => {


### PR DESCRIPTION
## やったこと
- Github API で組織アカウント一覧を取得
- アカウント一覧を検索セレクトボックスにセット

## 補足
細かい設計などは無視して動くレベルで実装を進めました。