### PR TITLE
リポジトリ一覧を取得するクエリの field で name => nameWithOwner に変更

### DIFF
--- a/renderer/src/hooks/useSearchRepository.ts
+++ b/renderer/src/hooks/useSearchRepository.ts
@@ -4,7 +4,7 @@ import { graphql } from 'relay-runtime';
 import type { useSearchRepositoryQuery } from './__generated__/useSearchRepositoryQuery.graphql';
 
 export type Repository = {
-  name: string;
+  nameWithOwner: string;
   url: string;
 };
 
@@ -13,7 +13,7 @@ const SearchRepositoryQuery = graphql`
     search(type: REPOSITORY, query: $query, last: 100) {
       nodes {
         ... on Repository {
-          name
+          nameWithOwner
           url
         }
       }
@@ -29,7 +29,7 @@ export const useSearchRepository = () => {
       account: string;
       keyword: string;
       isOrganization: boolean;
-    }): Promise<{ name: string; url: string }[]> => {
+    }): Promise<Repository[]> => {
       return new Promise((resolve) => {
         const accountModifier = options.isOrganization ? 'org' : 'user';
         const query = `${options.keyword} ${accountModifier}:${options.account}`;

--- a/renderer/src/pages/SelectRepositoryPage/SelectRepositoryPage.tsx
+++ b/renderer/src/pages/SelectRepositoryPage/SelectRepositoryPage.tsx
@@ -74,18 +74,21 @@ const RepositoryList = memo<RepositoryListProps>(
     return (
       <ul className={repositoryListStyle}>
         {repositories.map((repository) => (
-          <li key={repository.name} className={repositoryListItemStyle}>
+          <li
+            key={repository.nameWithOwner}
+            className={repositoryListItemStyle}
+          >
             <a
               href={repository.url}
               target="_blank"
               rel="noopner noreferrer"
               className={repositoryLinkStyle}
             >
-              {repository.name}
+              {repository.nameWithOwner}
             </a>
-            {subscribedRepositories.includes(repository.name) ? (
+            {subscribedRepositories.includes(repository.nameWithOwner) ? (
               <button
-                onClick={() => removeRepository(repository.name)}
+                onClick={() => removeRepository(repository.nameWithOwner)}
                 className={classNames(
                   iconButtonStyle,
                   themeFocusVisibleOutline
@@ -96,7 +99,7 @@ const RepositoryList = memo<RepositoryListProps>(
               </button>
             ) : (
               <button
-                onClick={() => addRepository(repository.name)}
+                onClick={() => addRepository(repository.nameWithOwner)}
                 className={classNames(
                   iconButtonStyle,
                   themeFocusVisibleOutline


### PR DESCRIPTION
## 概要
リポジトリ一覧を取得するGraphQLクエリを変更しました。
`name` フィールドを参照すると、組織アカウントの作成者で `review-cat` と表示されてしまい、アプリケーションのログインユーザーによってリポジトリ名が異なり正常にプルリク一覧を取得できない問題がありました。

`nameWithOwner` に変更することで一意で名前を取得するようにしました。