### PR TITLE
update vanilla-extract & vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@headlessui/react": "^1.4.0",
     "@primer/octicons-react": "^15.0.0",
-    "@vanilla-extract/css": "^1.1.1",
+    "@vanilla-extract/css": "^1.3.0",
     "classnames": "^2.3.1",
     "destyle.css": "^2.0.2",
     "jotai": "^1.1.3",
@@ -54,7 +54,7 @@
     "@types/relay-runtime": "^11.0.1",
     "@typescript-eslint/eslint-plugin": "^4.28.1",
     "@typescript-eslint/parser": "^4.28.1",
-    "@vanilla-extract/vite-plugin": "^1.0.0",
+    "@vanilla-extract/vite-plugin": "^2.0.0",
     "@vitejs/plugin-react-refresh": "^1.3.1",
     "babel-plugin-relay": "^11.0.2",
     "dotenv": "^10.0.0",
@@ -79,7 +79,7 @@
     "ts-jest": "^27.0.3",
     "ts-mockito": "^2.6.1",
     "typescript": "^4.4.2",
-    "vite": "^2.3.5",
+    "vite": "^2.5.1",
     "vite-plugin-relay": "^1.0.3"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ specifiers:
   '@types/relay-runtime': ^11.0.1
   '@typescript-eslint/eslint-plugin': ^4.28.1
   '@typescript-eslint/parser': ^4.28.1
-  '@vanilla-extract/css': ^1.1.1
-  '@vanilla-extract/vite-plugin': ^1.0.0
+  '@vanilla-extract/css': ^1.3.0
+  '@vanilla-extract/vite-plugin': ^2.0.0
   '@vitejs/plugin-react-refresh': ^1.3.1
   babel-plugin-relay: ^11.0.2
   classnames: ^2.3.1
@@ -52,13 +52,13 @@ specifiers:
   ts-jest: ^27.0.3
   ts-mockito: ^2.6.1
   typescript: ^4.4.2
-  vite: ^2.3.5
+  vite: ^2.5.1
   vite-plugin-relay: ^1.0.3
 
 dependencies:
   '@headlessui/react': 1.4.0_react-dom@17.0.2+react@17.0.2
   '@primer/octicons-react': 15.0.0_react@17.0.2
-  '@vanilla-extract/css': 1.1.1
+  '@vanilla-extract/css': 1.3.0
   classnames: 2.3.1
   destyle.css: 2.0.2
   jotai: 1.1.3_react@17.0.2
@@ -84,7 +84,7 @@ devDependencies:
   '@types/relay-runtime': 11.0.1
   '@typescript-eslint/eslint-plugin': 4.28.1_37f0f460765b2093f7d07e89ffead7ae
   '@typescript-eslint/parser': 4.28.1_eslint@7.30.0+typescript@4.4.2
-  '@vanilla-extract/vite-plugin': 1.0.0
+  '@vanilla-extract/vite-plugin': 2.0.0_vite@2.5.1
   '@vitejs/plugin-react-refresh': 1.3.4
   babel-plugin-relay: 11.0.2_graphql@15.5.1
   dotenv: 10.0.0
@@ -109,8 +109,8 @@ devDependencies:
   ts-jest: 27.0.3_jest@27.0.6+typescript@4.4.2
   ts-mockito: 2.6.1
   typescript: 4.4.2
-  vite: 2.3.8
-  vite-plugin-relay: 1.0.3_vite@2.3.8
+  vite: 2.5.1
+  vite-plugin-relay: 1.0.3_vite@2.5.1
 
 packages:
 
@@ -1631,23 +1631,23 @@ packages:
       eslint-visitor-keys: 2.1.0
     dev: true
 
-  /@vanilla-extract/css/1.1.1:
-    resolution: {integrity: sha512-5dzFpruVkWAvm7bYMPFeH0MRcqbNNDBzLatYyfTRPLksw1Oc9uOs9g1L0y18NRf5Gufps1XZ2uwwbT7uX79PYA==}
+  /@vanilla-extract/css/1.3.0:
+    resolution: {integrity: sha512-JcXz0k7Xh7dxWxrUBktPdjojGnMlfEjiQIDHYtM1bJhWiInenvWujjwDR7TFoijBGSj5ovZjCH6twXPOvCz1Ww==}
     dependencies:
       '@emotion/hash': 0.8.0
       '@vanilla-extract/private': 1.0.1
-      chalk: 4.1.1
+      chalk: 4.1.2
       css-what: 5.0.1
       cssesc: 3.0.0
       csstype: 3.0.8
       dedent: 0.7.0
       deep-object-diff: 1.1.0
 
-  /@vanilla-extract/integration/1.0.1:
-    resolution: {integrity: sha512-dm1dLFewXCVXuXe+3BPb1iK/EFubxkzevLOepMY8z+wUIUv0xS8PdccY3n7vXPTsSNg5f3Bm3IkaL2ynj+LcJA==}
+  /@vanilla-extract/integration/1.2.0:
+    resolution: {integrity: sha512-mawQst1Kk8LnsTXNcQ5VBTmg11DeYgctUG/G/l4ELlaINUAdvc7mguuf46nqXA1lfkrMbjquaBeiZQ9/Vz6x0g==}
     dependencies:
-      '@vanilla-extract/css': 1.1.1
-      chalk: 4.1.1
+      '@vanilla-extract/css': 1.3.0
+      chalk: 4.1.2
       dedent: 0.7.0
       esbuild: 0.11.23
       eval: 0.1.6
@@ -1659,10 +1659,13 @@ packages:
   /@vanilla-extract/private/1.0.1:
     resolution: {integrity: sha512-ABrFJGSmF7a1M+eDTsIeAErPhIeRyBY3ypyLQPc4bUVEK1mvF7F2gx4fTP81pm12bkS0GhjSJtM854lcPWhB+w==}
 
-  /@vanilla-extract/vite-plugin/1.0.0:
-    resolution: {integrity: sha512-FMeAS67DlajKnQPHr+0X3k0Ua9ECSiBMhsZ9N4tMWfRR+kzzy6I4+R2CwKGNwJ66teLBS2Vhc2IjVxDxVAtfZA==}
+  /@vanilla-extract/vite-plugin/2.0.0_vite@2.5.1:
+    resolution: {integrity: sha512-6sNR8hA64PBAAiUSaXUk7QxoUatPZiyyJ4vYSn/5Ee4gZI0S1hvMa5IIse10sg4Du4n7rbhUXYKpLrQqSkk9Cw==}
+    peerDependencies:
+      vite: ^2.2.3
     dependencies:
-      '@vanilla-extract/integration': 1.0.1
+      '@vanilla-extract/integration': 1.2.0
+      vite: 2.5.1
     dev: true
 
   /@vitejs/plugin-react-refresh/1.3.4:
@@ -2322,6 +2325,14 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+    dev: true
+
+  /chalk/4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
 
   /char-regex/1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -2434,6 +2445,10 @@ packages:
 
   /colorette/1.2.2:
     resolution: {integrity: sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==}
+    dev: true
+
+  /colorette/1.3.0:
+    resolution: {integrity: sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==}
     dev: true
 
   /colors/1.0.3:
@@ -2990,8 +3005,8 @@ packages:
     requiresBuild: true
     dev: true
 
-  /esbuild/0.12.14:
-    resolution: {integrity: sha512-z8p+6FGiplR7a3pPonXREbm+8IeXjBGvDpVidZmGB/AJMsJSfGCU+n7KOMCazA9AwvagadRWBhiKorC0w9WJvw==}
+  /esbuild/0.12.24:
+    resolution: {integrity: sha512-C0ibY+HsXzYB6L/pLWEiWjMpghKsIc58Q5yumARwBQsHl9DXPakW+5NI/Y9w4YXiz0PEP6XTGTT/OV4Nnsmb4A==}
     hasBin: true
     requiresBuild: true
     dev: true
@@ -3871,8 +3886,8 @@ packages:
       has: 1.0.3
     dev: true
 
-  /is-core-module/2.5.0:
-    resolution: {integrity: sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==}
+  /is-core-module/2.6.0:
+    resolution: {integrity: sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==}
     dependencies:
       has: 1.0.3
     dev: true
@@ -5011,8 +5026,8 @@ packages:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: true
 
-  /nanoid/3.1.23:
-    resolution: {integrity: sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==}
+  /nanoid/3.1.25:
+    resolution: {integrity: sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
     dev: true
@@ -5328,12 +5343,12 @@ packages:
     dev: true
     optional: true
 
-  /postcss/8.3.5:
-    resolution: {integrity: sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==}
+  /postcss/8.3.6:
+    resolution: {integrity: sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      colorette: 1.2.2
-      nanoid: 3.1.23
+      colorette: 1.3.0
+      nanoid: 3.1.25
       source-map-js: 0.6.2
     dev: true
 
@@ -5732,7 +5747,7 @@ packages:
   /resolve/1.20.0:
     resolution: {integrity: sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==}
     dependencies:
-      is-core-module: 2.5.0
+      is-core-module: 2.6.0
       path-parse: 1.0.7
     dev: true
 
@@ -5782,8 +5797,8 @@ packages:
     dev: true
     optional: true
 
-  /rollup/2.52.7:
-    resolution: {integrity: sha512-55cSH4CCU6MaPr9TAOyrIC+7qFCHscL7tkNsm1MBfIJRRqRbCEY0mmeFn4Wg8FKsHtEH8r389Fz38r/o+kgXLg==}
+  /rollup/2.56.3:
+    resolution: {integrity: sha512-Au92NuznFklgQCUcV96iXlxUbHuB1vQMaH76DHl5M11TotjOHwqk9CwcrT78+Tnv4FN9uTBxq6p4EJoYkpyekg==}
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:
@@ -6477,7 +6492,7 @@ packages:
     dev: true
     optional: true
 
-  /vite-plugin-relay/1.0.3_vite@2.3.8:
+  /vite-plugin-relay/1.0.3_vite@2.5.1:
     resolution: {integrity: sha512-evzaMX19sMXQ7EJzqzzoNmss0o8XXMWHEQB9TMiEiLlVKg08NMkF4a2bWoiilsaW44q37qWbQZJ49WrkVOeHdQ==}
     peerDependencies:
       vite: '>2.0.0-0'
@@ -6485,20 +6500,20 @@ packages:
       '@babel/core': 7.14.6
       babel-plugin-relay: 11.0.2_graphql@15.5.1
       graphql: 15.5.1
-      vite: 2.3.8
+      vite: 2.5.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /vite/2.3.8:
-    resolution: {integrity: sha512-QiEx+iqNnJntSgSF2fWRQvRey9pORIrtNJzNyBJXwc+BdzWs83FQolX84cTBo393cfhObrtWa6180dAa4NLDiQ==}
-    engines: {node: '>=12.0.0'}
+  /vite/2.5.1:
+    resolution: {integrity: sha512-FwmLbbz8MB1pBs9dKoRDgpiqoijif8hSK1+NNUYc12/cnf+pM2UFhhQ1rcpXgbMhm/5c2USZdVAf0FSkSxaFDA==}
+    engines: {node: '>=12.2.0'}
     hasBin: true
     dependencies:
-      esbuild: 0.12.14
-      postcss: 8.3.5
+      esbuild: 0.12.24
+      postcss: 8.3.6
       resolve: 1.20.0
-      rollup: 2.52.7
+      rollup: 2.56.3
     optionalDependencies:
       fsevents: 2.3.2
     dev: true


### PR DESCRIPTION
今まで [Vite & vanilla-extract で HMR の時に CSS がリセットされない問題](https://github.com/seek-oss/vanilla-extract/issues/190)がありましたが、関連する下記のパッケージをアップデートすることで治ったそうなので対応しました。

- vite
- @vanilla-extract/vite-plugin
- @vanilla-extract/css

## 検証

HMR ではなくページリロードされるようになっていました。

## before

![____________________________2021-08-28_22 16 02](https://user-images.githubusercontent.com/13248811/131219476-5c4b519a-3bb8-4f35-873e-34c353698c4a.png)

### after 

![____________________________2021-08-28_22 17 35](https://user-images.githubusercontent.com/13248811/131219482-2bfa1922-4af1-498f-857f-7059fed2a883.png)

HMR でアップデートされてくれるのが望ましいなーとは思いますが、今もリロードしているのは変わりないので良いか、ということで PR にしました。