### PR TITLE
リポジトリ検索でログイン中のユーザーアカウントが表示されないバグを修正

### DIFF
--- a/renderer/src/hooks/useGItHubAccounts.spec.tsx
+++ b/renderer/src/hooks/useGItHubAccounts.spec.tsx
@@ -1,0 +1,70 @@
+import React, { ReactChild } from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { MockedProvider, MockedProviderProps } from '@apollo/client/testing';
+import {
+  SearchGitHubAccountsQueryResponse,
+  SearchGitHubAccountsQuery,
+  useGitHubAccounts,
+} from './useGitHubAccounts';
+
+const responseMock: SearchGitHubAccountsQueryResponse = {
+  viewer: {
+    login: 'test-user',
+    organizations: {
+      nodes: [
+        {
+          avatarUrl: 'https://test.com/images/1',
+          login: 'test-organization',
+        },
+        {
+          avatarUrl: 'https://test.com/images/2',
+          login: 'test-organization2',
+        },
+      ],
+    },
+  },
+};
+
+const graphQLMocks: MockedProviderProps['mocks'] = [
+  {
+    request: { query: SearchGitHubAccountsQuery },
+    result: {
+      data: {
+        ...responseMock,
+      },
+    },
+  },
+];
+
+describe('useGitHubAccounts', () => {
+  it('ログイン中のユーザーアカウントを一覧に含める', async () => {
+    const wrapper = ({ children }: { children: ReactChild }) => (
+      <MockedProvider mocks={graphQLMocks}>{children}</MockedProvider>
+    );
+    const { result, waitForNextUpdate } = renderHook(
+      () => useGitHubAccounts(),
+      { wrapper }
+    );
+
+    await waitForNextUpdate();
+
+    expect(result.current.accounts).toContain(responseMock.viewer.login);
+  });
+
+  it('ログイン中のユーザーが所属する組織アカウントを一覧に含める', async () => {
+    const wrapper = ({ children }: { children: ReactChild }) => (
+      <MockedProvider mocks={graphQLMocks}>{children}</MockedProvider>
+    );
+    const { result, waitForNextUpdate } = renderHook(
+      () => useGitHubAccounts(),
+      { wrapper }
+    );
+
+    await waitForNextUpdate();
+
+    const organizations = responseMock.viewer.organizations.nodes ?? [];
+    for (const org of organizations) {
+      expect(result.current.accounts).toContain(org?.login);
+    }
+  });
+});

--- a/renderer/src/hooks/useGitHubAccounts.ts
+++ b/renderer/src/hooks/useGitHubAccounts.ts
@@ -34,12 +34,19 @@ export const useGitHubAccounts = () => {
   );
 
   useEffect(() => {
-    const nodes = data?.viewer.organizations.nodes;
-    if (nodes == null) return;
+    const accounts = [];
 
-    const accounts = nodes
-      .map((node) => node?.login)
-      .filter((org) => org != null) as string[];
+    const user = data?.viewer.login;
+    if (user) {
+      accounts.push(user);
+    }
+
+    const organizations = data?.viewer.organizations.nodes ?? [];
+    for (const org of organizations) {
+      if (org?.login) {
+        accounts.push(org?.login);
+      }
+    }
 
     setAccounts(accounts);
   }, [data]);

--- a/renderer/src/hooks/useGitHubAccounts.ts
+++ b/renderer/src/hooks/useGitHubAccounts.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { gql, useQuery } from '@apollo/client';
 
-type SearchGitHubAccountsQueryResponse = {
+export type SearchGitHubAccountsQueryResponse = {
   readonly viewer: {
     readonly login: string;
     readonly organizations: {


### PR DESCRIPTION
## 概要
リポジトリ検索をする際に対象のアカウント一覧にログイン中のユーザーアカウントが表示されておらず選択できない状態だった。
※ 組織アカウントだけが選択できる状態

## やったこと
- テストコードの追加
- アカウント一覧にユーザーアカウントを含める修正