### PR TITLE
設定画面を実装（#27）

### DIFF
--- a/renderer/src/components/UserMenu/UserMenu.spec.tsx
+++ b/renderer/src/components/UserMenu/UserMenu.spec.tsx
@@ -2,35 +2,53 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { UserMenu } from './';
 import userEvent from '@testing-library/user-event';
+import { UserMenuProps } from '..';
+import { MemoryRouter } from 'react-router';
 
 describe('UserMenu', () => {
+  const renderUserMenu = (props: Partial<UserMenuProps> | undefined) => {
+    const defaultProps: UserMenuProps = {
+      user: {
+        avatarUrl: 'https://example.com/images/avatar.jpeg',
+        name: 'test',
+      },
+      onClickSignOut: jest.fn(),
+    };
+
+    const userMenuProps = {
+      ...defaultProps,
+      ...props,
+    };
+
+    return render(
+      <MemoryRouter>
+        <UserMenu {...userMenuProps} />
+      </MemoryRouter>
+    );
+  };
   it('ユーザー名を表示する', () => {
     const user = {
       avatarUrl: '',
       name: 'test',
     };
 
-    render(
-      <UserMenu
-        user={user}
-        onClickSignOut={() => {
-          return;
-        }}
-      />
-    );
+    renderUserMenu({ user });
 
     const userName = screen.queryByText(user.name);
     expect(userName).toBeInTheDocument();
   });
 
+  it('設定画面へ遷移するリンクを表示する', () => {
+    renderUserMenu(undefined);
+    const link = screen.getByText('設定').closest('a');
+
+    expect(link).toHaveAttribute('href', '/settings');
+  });
+
   it('ログアウトがクリックされた時に、onClickSignOut を実行する', () => {
     const handleClickSignOutMock = jest.fn();
-    const user = {
-      avatarUrl: '',
-      name: 'test',
-    };
 
-    render(<UserMenu user={user} onClickSignOut={handleClickSignOutMock} />);
+    renderUserMenu({ onClickSignOut: handleClickSignOutMock });
 
     const signOutButton = screen.getByText('ログアウト');
     userEvent.click(signOutButton);

--- a/renderer/src/components/UserMenu/UserMenu.tsx
+++ b/renderer/src/components/UserMenu/UserMenu.tsx
@@ -1,5 +1,6 @@
 import React, { FC, memo } from 'react';
-import { SignOutIcon } from '@primer/octicons-react';
+import { SignOutIcon, GearIcon } from '@primer/octicons-react';
+import { Link } from 'react-router-dom';
 import { User } from '../../models';
 import {
   listItemStyle,
@@ -19,6 +20,10 @@ export const UserMenu: FC<UserMenuProps> = memo(({ user, onClickSignOut }) => {
   return (
     <div className={userMenuStyle}>
       <div className={`${listItemStyle} ${userNameStyle}`}>{user.name}</div>
+      <Link to="/settings" className={`${listItemStyle} ${actionItemStyle}`}>
+        <GearIcon className={actionIconStyle} />
+        <span className={actionLabelStyle}>設定</span>
+      </Link>
       <button
         className={`${listItemStyle} ${actionItemStyle}`}
         onClick={onClickSignOut}

--- a/renderer/src/components/UserMenu/style.css.ts
+++ b/renderer/src/components/UserMenu/style.css.ts
@@ -3,6 +3,8 @@ import { themeVars } from '../../theme.css';
 import { space } from '../../themeStyleHelper';
 
 export const userMenuStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
   left: space(1),
   marginTop: space(0.5),
   width: 'max-content',
@@ -15,6 +17,8 @@ export const userMenuStyle = style({
 });
 
 export const listItemStyle = style({
+  display: 'flex',
+  alignItems: 'center',
   padding: `${space(1)} ${space(2)}`,
   lineHeight: '1.5',
   selectors: {
@@ -29,7 +33,8 @@ export const actionIconStyle = style({
 });
 
 export const actionLabelStyle = style({
-  marginLeft: space(0.5),
+  marginLeft: space(1),
+  lineHeight: 1.2,
 });
 
 export const userNameStyle = style({

--- a/renderer/src/components/routes/AppRoute/AppRoute.tsx
+++ b/renderer/src/components/routes/AppRoute/AppRoute.tsx
@@ -11,10 +11,12 @@ import {
   PullRequestListPage,
   SelectRepositoryPage,
 } from '../../../pages';
+import { SettingsPage } from '../../../pages/SettingsPage';
 import { PrivateRoute } from '../PrivateRoute';
 
 export const AppRoute = () => {
   const { settings } = useSettings();
+
   return (
     <Router>
       <Switch>
@@ -23,6 +25,9 @@ export const AppRoute = () => {
         </Route>
         <PrivateRoute path="/select-repository">
           <SelectRepositoryPage />
+        </PrivateRoute>
+        <PrivateRoute path="/settings">
+          <SettingsPage />
         </PrivateRoute>
         <PrivateRoute path="/">
           {settings.subscribedRepositories.length === 0 ? (

--- a/renderer/src/containers/SettingsContainer/SettingContainer.tsx
+++ b/renderer/src/containers/SettingsContainer/SettingContainer.tsx
@@ -1,0 +1,164 @@
+import React, { ChangeEvent, FC } from 'react';
+import { Link } from 'react-router-dom';
+import { XCircleFillIcon } from '@primer/octicons-react';
+import { useSettings } from '../../hooks';
+import {
+  settingSectionStyle,
+  settingSectionTitleStyle,
+  settingItemStyle,
+  settingItemLabelStyle,
+  settingItemListStyle,
+  deleteIconStyle,
+  repositoryListItemStyle,
+} from './style.css';
+import { Settings as SettingsModel } from '../../models';
+
+type SettingsProps = {
+  settings: SettingsModel;
+  onChangeNotifyReviewRequested: (event: ChangeEvent<HTMLInputElement>) => void;
+  onChangeShowsRequestedReviewPr: (
+    event: ChangeEvent<HTMLInputElement>
+  ) => void;
+  onChangedShowsInReviewPr: (event: ChangeEvent<HTMLInputElement>) => void;
+  onChangedShowsApprovedPr: (event: ChangeEvent<HTMLInputElement>) => void;
+  onClickDeleteRepository: (repository: string) => void;
+};
+
+const Settings: FC<SettingsProps> = ({
+  settings,
+  onChangeNotifyReviewRequested,
+  onChangeShowsRequestedReviewPr,
+  onChangedShowsInReviewPr,
+  onChangedShowsApprovedPr,
+  onClickDeleteRepository,
+}) => {
+  return (
+    <>
+      <div className={settingSectionStyle}>
+        <h2 className={settingSectionTitleStyle}>通知</h2>
+        <div className={settingItemListStyle}>
+          <div className={settingItemStyle}>
+            <input
+              type="checkbox"
+              id="notify-review-requested"
+              onChange={onChangeNotifyReviewRequested}
+              defaultChecked={settings.notifyReviewRequested}
+            />
+            <label
+              htmlFor="notify-review-requested"
+              className={settingItemLabelStyle}
+            >
+              レビューリクエスト時に通知を受け取る
+            </label>
+          </div>
+        </div>
+      </div>
+      <div className={settingSectionStyle}>
+        <h2 className={settingSectionTitleStyle}>PRの表示</h2>
+        <div className={settingItemListStyle}>
+          <div className={settingItemStyle}>
+            <input
+              type="checkbox"
+              id="shows-requested-review-pr"
+              onChange={onChangeShowsRequestedReviewPr}
+              defaultChecked={settings.showsRequestedReviewPR}
+            />
+            <label
+              htmlFor="shows-requested-review-pr"
+              className={settingItemLabelStyle}
+            >
+              レビュー待ちのPRを表示
+            </label>
+          </div>
+          <div className={settingItemStyle}>
+            <input
+              type="checkbox"
+              id="shows-in-review-pr"
+              onChange={onChangedShowsInReviewPr}
+              defaultChecked={settings.showsInReviewPR}
+            />
+            <label
+              htmlFor="shows-in-review-pr"
+              className={settingItemLabelStyle}
+            >
+              レビュー中のPRを表示
+            </label>
+          </div>
+          <div className={settingItemStyle}>
+            <input
+              type="checkbox"
+              id="shows-approved-pr"
+              onChange={onChangedShowsApprovedPr}
+              defaultChecked={settings.showsApprovedPR}
+            />
+            <label
+              htmlFor="shows-approved-pr"
+              className={settingItemLabelStyle}
+            >
+              承認済みのPRを表示
+            </label>
+          </div>
+        </div>
+      </div>
+      <div className={settingSectionStyle}>
+        <h2 className={settingSectionTitleStyle}>リポジトリ一覧</h2>
+        {settings.subscribedRepositories.map((repository) => (
+          <div className={repositoryListItemStyle} key={repository}>
+            <span>{repository}</span>
+            <button
+              aria-label="リポジトリを削除"
+              onClick={() => onClickDeleteRepository(repository)}
+            >
+              <XCircleFillIcon className={deleteIconStyle} size={16} />
+            </button>
+          </div>
+        ))}
+        <Link to="/select-repository">+ 追加</Link>
+      </div>
+    </>
+  );
+};
+
+export const SettingsContainer = () => {
+  const {
+    settings,
+    updateNotifyReviewRequested,
+    updateShowsPR,
+    removeSubscribedRepository,
+  } = useSettings();
+
+  const handleChangeNotifyReviewRequested = (
+    event: ChangeEvent<HTMLInputElement>
+  ) => {
+    updateNotifyReviewRequested(event.target.checked);
+  };
+
+  const handleShowsRequestedReview = (event: ChangeEvent<HTMLInputElement>) => {
+    updateShowsPR({
+      requestedReview: event.target.checked,
+    });
+  };
+
+  const handleShowsInReview = (event: ChangeEvent<HTMLInputElement>) => {
+    updateShowsPR({
+      inReview: event.target.checked,
+    });
+  };
+
+  const handleShowsApproved = (event: ChangeEvent<HTMLInputElement>) => {
+    updateShowsPR({
+      approved: event.target.checked,
+    });
+  };
+
+  return (
+    <Settings
+      settings={settings}
+      onChangeNotifyReviewRequested={handleChangeNotifyReviewRequested}
+      onChangeShowsRequestedReviewPr={handleShowsRequestedReview}
+      onChangedShowsInReviewPr={handleShowsInReview}
+      onChangedShowsApprovedPr={handleShowsApproved}
+      onClickDeleteRepository={removeSubscribedRepository}
+    />
+  );
+};

--- a/renderer/src/containers/SettingsContainer/SettingsContainer.spec.tsx
+++ b/renderer/src/containers/SettingsContainer/SettingsContainer.spec.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { SettingsContainer } from './SettingContainer';
+import userEvent from '@testing-library/user-event';
+import { Settings } from '../../models';
+import { MemoryRouter } from 'react-router';
+
+const defaultSettings: Settings = {
+  notifyReviewRequested: false,
+  showsRequestedReviewPR: true,
+  showsInReviewPR: true,
+  showsApprovedPR: true,
+  subscribedRepositories: ['test/testA', 'test/testB'],
+};
+
+const updateNotifyReviewRequestedMock: jest.Mock = jest.fn();
+const updateShowsPRMock: jest.Mock = jest.fn();
+const removeSubscribedRepositoryMock: jest.Mock = jest.fn();
+
+jest.mock('../../hooks/useSettings', () => ({
+  useSettings() {
+    return {
+      settings: defaultSettings,
+      updateNotifyReviewRequested: updateNotifyReviewRequestedMock,
+      updateShowsPR: updateShowsPRMock,
+      removeSubscribedRepository: removeSubscribedRepositoryMock,
+    };
+  },
+}));
+
+describe('SettingsContainer', () => {
+  beforeEach(() => {
+    updateNotifyReviewRequestedMock.mockReset();
+    updateShowsPRMock.mockReset();
+    removeSubscribedRepositoryMock.mockReset();
+  });
+
+  const renderSettingContainer = () => {
+    return render(
+      <MemoryRouter>
+        <SettingsContainer />
+      </MemoryRouter>
+    );
+  };
+
+  describe('通知設定', () => {
+    it('チェックボックスがクリックされた時にコールバック関数が呼ばれる', () => {
+      renderSettingContainer();
+
+      const checkbox =
+        screen.getByLabelText('レビューリクエスト時に通知を受け取る');
+      userEvent.click(checkbox);
+
+      expect(updateNotifyReviewRequestedMock).toBeCalledWith(
+        !defaultSettings.notifyReviewRequested
+      );
+    });
+  });
+
+  describe('PR表示の設定', () => {
+    it.each([
+      {
+        label: 'レビュー待ちのPRを表示',
+        expected: {
+          requestedReview: !defaultSettings.showsRequestedReviewPR,
+        },
+      },
+      {
+        label: 'レビュー中のPRを表示',
+        expected: {
+          inReview: !defaultSettings.showsInReviewPR,
+        },
+      },
+      {
+        label: '承認済みのPRを表示',
+        expected: {
+          approved: !defaultSettings.showsApprovedPR,
+        },
+      },
+    ])(
+      '$label のチェックボックスがクリックされた時にコールバック関数が呼ばれる',
+      ({ label, expected }) => {
+        renderSettingContainer();
+
+        const checkbox = screen.getByLabelText(label);
+        userEvent.click(checkbox);
+
+        expect(updateShowsPRMock).toBeCalledWith(expected);
+      }
+    );
+  });
+
+  describe('リポジトリ一覧', () => {
+    it('監視しているリポジトリの一覧を表示する', () => {
+      renderSettingContainer();
+
+      const repositories = defaultSettings.subscribedRepositories.map(
+        (repository) => {
+          return screen.queryByText(repository);
+        }
+      );
+
+      for (const repository of repositories) {
+        expect(repository).toBeInTheDocument();
+      }
+    });
+
+    it('削除アイコンをクリックした時にコールバック関数が呼ばれる', () => {
+      renderSettingContainer();
+
+      const deleteIcon = screen.getAllByRole('button', {
+        name: 'リポジトリを削除',
+      })[0];
+      userEvent.click(deleteIcon);
+
+      expect(removeSubscribedRepositoryMock).toBeCalledWith('test/testA');
+    });
+  });
+});

--- a/renderer/src/containers/SettingsContainer/index.ts
+++ b/renderer/src/containers/SettingsContainer/index.ts
@@ -1,0 +1,1 @@
+export * from './SettingContainer';

--- a/renderer/src/containers/SettingsContainer/style.css.ts
+++ b/renderer/src/containers/SettingsContainer/style.css.ts
@@ -1,0 +1,42 @@
+import { style } from '@vanilla-extract/css';
+import { themeVars } from '../../theme.css';
+import { space } from '../../themeStyleHelper';
+
+export const settingSectionStyle = style({
+  marginBottom: space(2),
+});
+
+export const settingSectionTitleStyle = style({
+  fontSize: '1.6rem',
+  fontWeight: 'bold',
+  lineHeight: '1.5',
+});
+
+export const settingItemListStyle = style({
+  paddingTop: space(0.5),
+});
+
+export const settingItemStyle = style({
+  display: 'flex',
+  alignItems: 'center',
+  fontSize: '1.4rem',
+  lineHeight: '1.5',
+});
+
+export const settingItemLabelStyle = style({
+  marginLeft: space(1),
+});
+
+export const repositoryListItemStyle = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: space(1),
+  lineHeight: 1.5,
+});
+
+export const deleteIconStyle = style({
+  color: themeVars.color.red,
+  ':hover': {
+    cursor: 'pointer',
+  },
+});

--- a/renderer/src/hooks/useSettings.ts
+++ b/renderer/src/hooks/useSettings.ts
@@ -19,13 +19,13 @@ export const useSettings = () => {
 
   const updateShowsPR = useCallback(
     ({
-      requestedReview,
-      inReview,
-      approved,
+      requestedReview = settings.showsRequestedReviewPR,
+      inReview = settings.showsInReviewPR,
+      approved = settings.showsApprovedPR,
     }: {
-      requestedReview: boolean;
-      inReview: boolean;
-      approved: boolean;
+      requestedReview?: boolean;
+      inReview?: boolean;
+      approved?: boolean;
     }) => {
       dispatch({
         type: UPDATE_ACTION,
@@ -36,7 +36,7 @@ export const useSettings = () => {
         },
       });
     },
-    [dispatch]
+    [dispatch, settings]
   );
 
   const addSubscribedRepository = useCallback(

--- a/renderer/src/layouts/BaseLayout/styles.css.ts
+++ b/renderer/src/layouts/BaseLayout/styles.css.ts
@@ -15,4 +15,5 @@ export const navContainerStyle = style({
   top: '0',
   left: '0',
   height: '100vh',
+  zIndex: 100,
 });

--- a/renderer/src/pages/SettingsPage/SettingsPage.tsx
+++ b/renderer/src/pages/SettingsPage/SettingsPage.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { BaseLayout } from '../../layouts/BaseLayout';
+import {
+  titleWrapperStyle,
+  titleStyle,
+  rootStyle,
+  contentStyle,
+} from './style.css';
+import { SettingsContainer } from '../../containers/SettingsContainer';
+
+export const SettingsPage = () => {
+  return (
+    <BaseLayout>
+      <div className={rootStyle}>
+        <div className={titleWrapperStyle}>
+          <h1 className={titleStyle}>設定</h1>
+        </div>
+        <div className={contentStyle}>
+          <SettingsContainer />
+        </div>
+      </div>
+    </BaseLayout>
+  );
+};

--- a/renderer/src/pages/SettingsPage/index.ts
+++ b/renderer/src/pages/SettingsPage/index.ts
@@ -1,0 +1,1 @@
+export * from './SettingsPage';

--- a/renderer/src/pages/SettingsPage/style.css.ts
+++ b/renderer/src/pages/SettingsPage/style.css.ts
@@ -1,0 +1,22 @@
+import { style } from '@vanilla-extract/css';
+import { themeVars } from '../../theme.css';
+import { space } from '../../themeStyleHelper';
+
+export const rootStyle = style({
+  padding: space(4),
+});
+
+export const titleWrapperStyle = style({
+  paddingBottom: space(1),
+  borderBottom: `1px solid ${themeVars.color.gray100}`,
+});
+
+export const titleStyle = style({
+  fontSize: '1.8rem',
+  fontWeight: 'bold',
+  lineHeight: '1.5',
+});
+
+export const contentStyle = style({
+  paddingTop: space(1),
+});

--- a/renderer/src/theme.css.ts
+++ b/renderer/src/theme.css.ts
@@ -9,6 +9,7 @@ const colors = {
   gray900: '#333',
   accent: '#f2b24e',
   green: '#0A9710',
+  red: '#EB5757',
 };
 
 export const themeVars = createGlobalTheme(':root', {


### PR DESCRIPTION
## やったこと
- 設定画面の実装
  - 通知設定の ON/OFF の切り替え
  - 表示するPRの ON/OFF の切り替え
  - 監視しているリポジトリの一覧の表示
  - 監視するリポジトリの削除
  - リポジトリ選択画面への遷移
- 設定画面へのリンクをユーザーメニューに追加
- ユニットテストの追加

## 補足
### リポジトリ選択について
現状はリポジトリ選択画面へリンクにしていますが、使い勝手を考慮すると設定画面に戻る遷移などを追加する必要があります。
その実装を追加すると色々と複雑になる予感があるので、リポジトリ選択をコンポーネントとして切り出して初期デザイン案のようにモーダルで表示するようにする予定です。

close #27 