### PR TITLE
設定画面のリポジトリ追加をモーダル表示するように変更

### DIFF
--- a/renderer/src/components/SearchRepository/style.css.ts
+++ b/renderer/src/components/SearchRepository/style.css.ts
@@ -2,7 +2,6 @@ import { style } from '@vanilla-extract/css';
 import { space } from '../../themeStyleHelper';
 
 export const rootStyle = style({
-  marginTop: space(4),
   display: 'grid',
   gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
   columnGap: space(1),

--- a/renderer/src/components/SelectRepositoryModal/SelectRepositoryModal.tsx
+++ b/renderer/src/components/SelectRepositoryModal/SelectRepositoryModal.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Dialog } from '@headlessui/react';
+import { XIcon } from '@primer/octicons-react';
+import { SelectRepositoryContainer } from '../../containers/SelectRepositoryContainer';
+import {
+  dialogStyle,
+  overlayStyle,
+  contentStyle,
+  closeButtonStyle,
+} from './style.css';
+
+type SelectRepositoryModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export const SelectRepositoryModal = React.memo<SelectRepositoryModalProps>(
+  (props) => {
+    return (
+      <Dialog
+        open={props.isOpen}
+        onClose={props.onClose}
+        className={dialogStyle}
+      >
+        <div className={contentStyle}>
+          <button onClick={props.onClose} className={closeButtonStyle}>
+            <XIcon />
+          </button>
+          <SelectRepositoryContainer />
+        </div>
+        <Dialog.Overlay className={overlayStyle} />
+      </Dialog>
+    );
+  }
+);

--- a/renderer/src/components/SelectRepositoryModal/index.ts
+++ b/renderer/src/components/SelectRepositoryModal/index.ts
@@ -1,0 +1,1 @@
+export * from './SelectRepositoryModal';

--- a/renderer/src/components/SelectRepositoryModal/style.css.ts
+++ b/renderer/src/components/SelectRepositoryModal/style.css.ts
@@ -1,6 +1,5 @@
 import { style } from '@vanilla-extract/css';
 import { themeVars } from '../../theme.css';
-import { space } from '../../themeStyleHelper';
 
 export const dialogStyle = style({
   display: 'flex',

--- a/renderer/src/components/SelectRepositoryModal/style.css.ts
+++ b/renderer/src/components/SelectRepositoryModal/style.css.ts
@@ -1,0 +1,36 @@
+import { style } from '@vanilla-extract/css';
+import { themeVars } from '../../theme.css';
+import { space } from '../../themeStyleHelper';
+
+export const dialogStyle = style({
+  display: 'flex',
+  justifyContent: 'center',
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  width: '100%',
+  zIndex: 20,
+});
+
+export const overlayStyle = style({
+  position: 'fixed',
+  width: '100%',
+  height: '100%',
+  background: 'rgba(0,0,0,0.8)',
+});
+
+export const contentStyle = style({
+  position: 'relative',
+  borderRadius: '16px',
+  backgroundColor: themeVars.bgColor.base,
+  zIndex: 10,
+  padding: '32px 24px',
+  marginTop: '48px',
+});
+
+export const closeButtonStyle = style({
+  position: 'absolute',
+  color: themeVars.color.gray500,
+  top: '8px',
+  right: '8px',
+});

--- a/renderer/src/containers/SelectRepositoryContainer/SelectRepositoryContainer.spec.tsx
+++ b/renderer/src/containers/SelectRepositoryContainer/SelectRepositoryContainer.spec.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SelectRepositoryContainer } from './SelectRepositoryContainer';
+import { Repository } from '../../hooks/useSearchRepository';
+
+const repositories: Repository[] = [
+  {
+    nameWithOwner: 'test/testA',
+    url: 'https://github.com/test/testA',
+  },
+  {
+    nameWithOwner: 'test/testB',
+    url: 'https://github.com/test/testB',
+  },
+];
+
+jest.mock('../../components/SearchRepository', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  SearchRepository: (props: any) => {
+    return (
+      <div>
+        <button onClick={() => props.onSearch(repositories)}>検索</button>
+        {props.children}
+      </div>
+    );
+  },
+}));
+
+describe('SelectRepositoryContainer', () => {
+  const renderSelectRepositoryContainer = () => {
+    return render(<SelectRepositoryContainer />);
+  };
+
+  it('検索結果のリポジトリ一覧を表示する', () => {
+    renderSelectRepositoryContainer();
+    const button = screen.getByText('検索');
+    userEvent.click(button);
+
+    for (const repository of repositories) {
+      expect(screen.queryByText(repository.nameWithOwner)).toBeInTheDocument();
+    }
+  });
+});

--- a/renderer/src/containers/SelectRepositoryContainer/SelectRepositoryContainer.tsx
+++ b/renderer/src/containers/SelectRepositoryContainer/SelectRepositoryContainer.tsx
@@ -1,15 +1,6 @@
 import React, { memo, useCallback, useState } from 'react';
-import classNames from 'classnames';
-import { CheckCircleFillIcon, PlusCircleIcon } from '@primer/octicons-react';
+import { SelectRepositoryList } from './SelectRepositoryList';
 import { SearchRepository } from '../../components';
-import {
-  repositoryListStyle,
-  repositoryLinkStyle,
-  iconButtonStyle,
-  iconStyle,
-  repositoryListItemStyle,
-} from './style.css';
-import { themeFocusVisibleOutline } from '../../theme.css';
 import { Repository } from '../../hooks/useSearchRepository';
 import { useSettings } from '../../hooks';
 
@@ -18,7 +9,7 @@ export const SelectRepositoryContainer = memo(() => {
   const { settings, addSubscribedRepository, removeSubscribedRepository } =
     useSettings();
 
-  const handleSearch = useCallback(async (repositories: Repository[]) => {
+  const handleSearch = useCallback((repositories: Repository[]) => {
     setRepositories(repositories);
   }, []);
 
@@ -26,7 +17,7 @@ export const SelectRepositoryContainer = memo(() => {
     <div>
       <SearchRepository onSearch={handleSearch} />
       {repositories.length > 0 && (
-        <RepositoryList
+        <SelectRepositoryList
           repositories={repositories}
           subscribedRepositories={settings.subscribedRepositories}
           addRepository={addSubscribedRepository}
@@ -36,62 +27,3 @@ export const SelectRepositoryContainer = memo(() => {
     </div>
   );
 });
-
-type RepositoryListProps = {
-  repositories: Repository[];
-  subscribedRepositories: string[];
-  addRepository: (repository: string) => void;
-  removeRepository: (repository: string) => void;
-};
-
-const RepositoryList = memo<RepositoryListProps>(
-  ({
-    repositories,
-    subscribedRepositories,
-    addRepository,
-    removeRepository,
-  }) => {
-    return (
-      <ul className={repositoryListStyle}>
-        {repositories.map((repository) => (
-          <li
-            key={repository.nameWithOwner}
-            className={repositoryListItemStyle}
-          >
-            <a
-              href={repository.url}
-              target="_blank"
-              rel="noopner noreferrer"
-              className={repositoryLinkStyle}
-            >
-              {repository.nameWithOwner}
-            </a>
-            {subscribedRepositories.includes(repository.nameWithOwner) ? (
-              <button
-                onClick={() => removeRepository(repository.nameWithOwner)}
-                className={classNames(
-                  iconButtonStyle,
-                  themeFocusVisibleOutline
-                )}
-                title={`${repository}を設定から削除する`}
-              >
-                <CheckCircleFillIcon className={iconStyle} size={24} />
-              </button>
-            ) : (
-              <button
-                onClick={() => addRepository(repository.nameWithOwner)}
-                className={classNames(
-                  iconButtonStyle,
-                  themeFocusVisibleOutline
-                )}
-                title={`${repository}を設定に追加する`}
-              >
-                <PlusCircleIcon className={iconStyle} size={24} />
-              </button>
-            )}
-          </li>
-        ))}
-      </ul>
-    );
-  }
-);

--- a/renderer/src/containers/SelectRepositoryContainer/SelectRepositoryContainer.tsx
+++ b/renderer/src/containers/SelectRepositoryContainer/SelectRepositoryContainer.tsx
@@ -1,0 +1,97 @@
+import React, { memo, useCallback, useState } from 'react';
+import classNames from 'classnames';
+import { CheckCircleFillIcon, PlusCircleIcon } from '@primer/octicons-react';
+import { SearchRepository } from '../../components';
+import {
+  repositoryListStyle,
+  repositoryLinkStyle,
+  iconButtonStyle,
+  iconStyle,
+  repositoryListItemStyle,
+} from './style.css';
+import { themeFocusVisibleOutline } from '../../theme.css';
+import { Repository } from '../../hooks/useSearchRepository';
+import { useSettings } from '../../hooks';
+
+export const SelectRepositoryContainer = memo(() => {
+  const [repositories, setRepositories] = useState<Repository[]>([]);
+  const { settings, addSubscribedRepository, removeSubscribedRepository } =
+    useSettings();
+
+  const handleSearch = useCallback(async (repositories: Repository[]) => {
+    setRepositories(repositories);
+  }, []);
+
+  return (
+    <div>
+      <SearchRepository onSearch={handleSearch} />
+      {repositories.length > 0 && (
+        <RepositoryList
+          repositories={repositories}
+          subscribedRepositories={settings.subscribedRepositories}
+          addRepository={addSubscribedRepository}
+          removeRepository={removeSubscribedRepository}
+        />
+      )}
+    </div>
+  );
+});
+
+type RepositoryListProps = {
+  repositories: Repository[];
+  subscribedRepositories: string[];
+  addRepository: (repository: string) => void;
+  removeRepository: (repository: string) => void;
+};
+
+const RepositoryList = memo<RepositoryListProps>(
+  ({
+    repositories,
+    subscribedRepositories,
+    addRepository,
+    removeRepository,
+  }) => {
+    return (
+      <ul className={repositoryListStyle}>
+        {repositories.map((repository) => (
+          <li
+            key={repository.nameWithOwner}
+            className={repositoryListItemStyle}
+          >
+            <a
+              href={repository.url}
+              target="_blank"
+              rel="noopner noreferrer"
+              className={repositoryLinkStyle}
+            >
+              {repository.nameWithOwner}
+            </a>
+            {subscribedRepositories.includes(repository.nameWithOwner) ? (
+              <button
+                onClick={() => removeRepository(repository.nameWithOwner)}
+                className={classNames(
+                  iconButtonStyle,
+                  themeFocusVisibleOutline
+                )}
+                title={`${repository}を設定から削除する`}
+              >
+                <CheckCircleFillIcon className={iconStyle} size={24} />
+              </button>
+            ) : (
+              <button
+                onClick={() => addRepository(repository.nameWithOwner)}
+                className={classNames(
+                  iconButtonStyle,
+                  themeFocusVisibleOutline
+                )}
+                title={`${repository}を設定に追加する`}
+              >
+                <PlusCircleIcon className={iconStyle} size={24} />
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+    );
+  }
+);

--- a/renderer/src/containers/SelectRepositoryContainer/SelectRepositoryContainer.tsx
+++ b/renderer/src/containers/SelectRepositoryContainer/SelectRepositoryContainer.tsx
@@ -3,6 +3,7 @@ import { SelectRepositoryList } from './SelectRepositoryList';
 import { SearchRepository } from '../../components';
 import { Repository } from '../../hooks/useSearchRepository';
 import { useSettings } from '../../hooks';
+import { repositoryListWrapperStyle } from './style.css';
 
 export const SelectRepositoryContainer = memo(() => {
   const [repositories, setRepositories] = useState<Repository[]>([]);
@@ -17,12 +18,14 @@ export const SelectRepositoryContainer = memo(() => {
     <div>
       <SearchRepository onSearch={handleSearch} />
       {repositories.length > 0 && (
-        <SelectRepositoryList
-          repositories={repositories}
-          subscribedRepositories={settings.subscribedRepositories}
-          addRepository={addSubscribedRepository}
-          removeRepository={removeSubscribedRepository}
-        />
+        <div className={repositoryListWrapperStyle}>
+          <SelectRepositoryList
+            repositories={repositories}
+            subscribedRepositories={settings.subscribedRepositories}
+            addRepository={addSubscribedRepository}
+            removeRepository={removeSubscribedRepository}
+          />
+        </div>
       )}
     </div>
   );

--- a/renderer/src/containers/SelectRepositoryContainer/SelectRepositoryList.spec.tsx
+++ b/renderer/src/containers/SelectRepositoryContainer/SelectRepositoryList.spec.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { render, screen, queryByRole } from '@testing-library/react';
+import {
+  SelectRepositoryList,
+  SelectRepositoryListProps,
+} from './SelectRepositoryList';
+import userEvent from '@testing-library/user-event';
+
+describe('SelectRepositoryList', () => {
+  const renderSelectRepositoryList = (
+    props: Partial<SelectRepositoryListProps> = {}
+  ) => {
+    const defaultProps: SelectRepositoryListProps = {
+      repositories: [
+        {
+          nameWithOwner: 'test/testA',
+          url: 'https://github.com/test/testA',
+        },
+        {
+          nameWithOwner: 'test/testB',
+          url: 'https://github.com/test/testB',
+        },
+      ],
+      subscribedRepositories: ['test/testA'],
+      addRepository: jest.fn(),
+      removeRepository: jest.fn(),
+    };
+    return render(<SelectRepositoryList {...{ ...defaultProps, ...props }} />);
+  };
+
+  it('リポジトリの一覧を表示する', () => {
+    const repositories = [
+      {
+        nameWithOwner: 'test/testA',
+        url: 'https://github.com/test/testA',
+      },
+      {
+        nameWithOwner: 'test/testB',
+        url: 'https://github.com/test/testB',
+      },
+    ];
+    renderSelectRepositoryList({ repositories });
+
+    for (const repository of repositories) {
+      expect(screen.queryByText(repository.nameWithOwner)).toBeInTheDocument();
+    }
+  });
+
+  describe('リポジトリの追加', () => {
+    it('設定に未登録のリポジトリの場合は追加アイコンを表示する', () => {
+      const repositories = [
+        {
+          nameWithOwner: 'test/testA',
+          url: '',
+        },
+      ];
+      renderSelectRepositoryList({ repositories, subscribedRepositories: [] });
+
+      const addRepositoryButton = screen.getByRole('button', {
+        name: 'リポジトリを設定に追加する',
+      });
+      const icon = queryByRole(addRepositoryButton, 'img', { hidden: true });
+
+      expect(icon).toBeInTheDocument();
+    });
+
+    it('追加アイコンをクリックすることでリポジトリを設定に追加するコールバック関数が呼ばれる', () => {
+      const repositories = [
+        {
+          nameWithOwner: 'test/testA',
+          url: '',
+        },
+      ];
+      const addRepositoryMock = jest.fn();
+      renderSelectRepositoryList({
+        repositories,
+        subscribedRepositories: [],
+        addRepository: addRepositoryMock,
+      });
+
+      const addRepositoryButton = screen.getByRole('button', {
+        name: 'リポジトリを設定に追加する',
+      });
+      userEvent.click(addRepositoryButton);
+
+      expect(addRepositoryMock).toBeCalledWith(repositories[0].nameWithOwner);
+    });
+  });
+
+  describe('リポジトリの削除', () => {
+    it('設定に登録済みのリポジトリは追加済みのアイコンを表示する', () => {
+      const repositories = [
+        {
+          nameWithOwner: 'test/testA',
+          url: '',
+        },
+      ];
+      renderSelectRepositoryList({
+        repositories,
+        subscribedRepositories: ['test/testA'],
+      });
+
+      const removeRepositoryButton = screen.getByRole('button', {
+        name: '設定からリポジトリを削除する',
+      });
+      const icon = queryByRole(removeRepositoryButton, 'img', { hidden: true });
+
+      expect(icon).toBeInTheDocument();
+    });
+
+    it('追加済みのアイコンをクリックすることでリポジトリを設定から削除するコールバック関数が呼ばれる', () => {
+      const repositories = [
+        {
+          nameWithOwner: 'test/testA',
+          url: '',
+        },
+      ];
+      const removeRepositoryMock = jest.fn();
+      renderSelectRepositoryList({
+        repositories,
+        subscribedRepositories: ['test/testA'],
+        removeRepository: removeRepositoryMock,
+      });
+
+      const removeRepositoryButton = screen.getByRole('button', {
+        name: '設定からリポジトリを削除する',
+      });
+      userEvent.click(removeRepositoryButton);
+
+      expect(removeRepositoryMock).toBeCalledWith(
+        repositories[0].nameWithOwner
+      );
+    });
+  });
+});

--- a/renderer/src/containers/SelectRepositoryContainer/SelectRepositoryList.tsx
+++ b/renderer/src/containers/SelectRepositoryContainer/SelectRepositoryList.tsx
@@ -1,0 +1,113 @@
+import React, { memo, FC } from 'react';
+import classNames from 'classnames';
+import { CheckCircleFillIcon, PlusCircleIcon } from '@primer/octicons-react';
+import {
+  repositoryListStyle,
+  repositoryLinkStyle,
+  iconButtonStyle,
+  iconStyle,
+  repositoryListItemStyle,
+} from './style.css';
+import { themeFocusVisibleOutline } from '../../theme.css';
+import { Repository } from '../../hooks/useSearchRepository';
+
+type AddRepositoryButtonProps = {
+  repository: Repository;
+  onClick: (repository: string) => void;
+};
+
+const AddRepositoryButton = memo<AddRepositoryButtonProps>(
+  ({ repository, onClick }) => {
+    return (
+      <button
+        onClick={() => onClick(repository.nameWithOwner)}
+        className={classNames(iconButtonStyle, themeFocusVisibleOutline)}
+        aria-label="リポジトリを設定に追加する"
+      >
+        <PlusCircleIcon className={iconStyle} size={24} />
+      </button>
+    );
+  }
+);
+
+type DeleteRepositoryButtonProps = {
+  repository: Repository;
+  onClick: (repository: string) => void;
+};
+
+const DeleteRepositoryButton = memo<DeleteRepositoryButtonProps>(
+  ({ repository, onClick }) => {
+    return (
+      <button
+        onClick={() => onClick(repository.nameWithOwner)}
+        className={classNames(iconButtonStyle, themeFocusVisibleOutline)}
+        aria-label="設定からリポジトリを削除する"
+      >
+        <CheckCircleFillIcon className={iconStyle} size={24} />
+      </button>
+    );
+  }
+);
+
+type RepositoryListItemProps = {
+  repository: Repository;
+  subscribed: boolean;
+  addRepository: SelectRepositoryListProps['addRepository'];
+  removeRepository: SelectRepositoryListProps['removeRepository'];
+};
+
+const RepositoryListItem = memo<RepositoryListItemProps>(
+  ({ repository, subscribed, addRepository, removeRepository }) => {
+    return (
+      <li className={repositoryListItemStyle}>
+        <a
+          href={repository.url}
+          target="_blank"
+          rel="noopner noreferrer"
+          className={repositoryLinkStyle}
+        >
+          {repository.nameWithOwner}
+        </a>
+        {subscribed ? (
+          <DeleteRepositoryButton
+            repository={repository}
+            onClick={removeRepository}
+          />
+        ) : (
+          <AddRepositoryButton
+            repository={repository}
+            onClick={addRepository}
+          />
+        )}
+      </li>
+    );
+  }
+);
+
+export type SelectRepositoryListProps = {
+  repositories: Repository[];
+  subscribedRepositories: string[];
+  addRepository: (repository: string) => void;
+  removeRepository: (repository: string) => void;
+};
+
+export const SelectRepositoryList: FC<SelectRepositoryListProps> = ({
+  repositories,
+  subscribedRepositories,
+  addRepository,
+  removeRepository,
+}) => {
+  return (
+    <ul className={repositoryListStyle}>
+      {repositories.map((repository) => (
+        <RepositoryListItem
+          key={repository.nameWithOwner}
+          repository={repository}
+          subscribed={subscribedRepositories.includes(repository.nameWithOwner)}
+          addRepository={addRepository}
+          removeRepository={removeRepository}
+        />
+      ))}
+    </ul>
+  );
+};

--- a/renderer/src/containers/SelectRepositoryContainer/index.ts
+++ b/renderer/src/containers/SelectRepositoryContainer/index.ts
@@ -1,0 +1,1 @@
+export * from './SelectRepositoryContainer';

--- a/renderer/src/containers/SelectRepositoryContainer/style.css.ts
+++ b/renderer/src/containers/SelectRepositoryContainer/style.css.ts
@@ -2,8 +2,13 @@ import { style } from '@vanilla-extract/css';
 import { themeVars } from '../../theme.css';
 import { space } from '../../themeStyleHelper';
 
-export const repositoryListStyle = style({
+export const repositoryListWrapperStyle = style({
   marginTop: space(2),
+  maxHeight: 280,
+  overflowY: 'scroll',
+});
+
+export const repositoryListStyle = style({
   fontSize: '1.4rem',
 });
 

--- a/renderer/src/containers/SelectRepositoryContainer/style.css.ts
+++ b/renderer/src/containers/SelectRepositoryContainer/style.css.ts
@@ -1,0 +1,36 @@
+import { style } from '@vanilla-extract/css';
+import { themeVars } from '../../theme.css';
+import { space } from '../../themeStyleHelper';
+
+export const repositoryListStyle = style({
+  marginTop: space(2),
+  fontSize: '1.4rem',
+});
+
+export const repositoryListItemStyle = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  padding: `${space(0.5)} 0`,
+  ':first-child': {
+    paddingTop: 0,
+  },
+});
+
+export const repositoryLinkStyle = style({
+  transition: 'opacity 0.1s ease-in',
+  width: '100%',
+  ':hover': {
+    opacity: 0.7,
+  },
+});
+
+export const iconButtonStyle = style({
+  ':hover': {
+    cursor: 'pointer',
+  },
+});
+
+export const iconStyle = style({
+  color: themeVars.color.green,
+});

--- a/renderer/src/containers/SettingsContainer/SettingContainer.tsx
+++ b/renderer/src/containers/SettingsContainer/SettingContainer.tsx
@@ -1,5 +1,4 @@
-import React, { ChangeEvent, FC } from 'react';
-import { Link } from 'react-router-dom';
+import React, { ChangeEvent, FC, useState } from 'react';
 import { XCircleFillIcon } from '@primer/octicons-react';
 import { useSettings } from '../../hooks';
 import {
@@ -10,8 +9,13 @@ import {
   settingItemListStyle,
   deleteIconStyle,
   repositoryListItemStyle,
+  addRepositoryStyle,
+  deleteButtonStyle,
+  repositoryListStyle,
+  ellipsisStyle,
 } from './style.css';
 import { Settings as SettingsModel } from '../../models';
+import { SelectRepositoryModal } from '../../components/SelectRepositoryModal';
 
 type SettingsProps = {
   settings: SettingsModel;
@@ -24,100 +28,118 @@ type SettingsProps = {
   onClickDeleteRepository: (repository: string) => void;
 };
 
-const Settings: FC<SettingsProps> = ({
-  settings,
-  onChangeNotifyReviewRequested,
-  onChangeShowsRequestedReviewPr,
-  onChangedShowsInReviewPr,
-  onChangedShowsApprovedPr,
-  onClickDeleteRepository,
-}) => {
-  return (
-    <>
-      <div className={settingSectionStyle}>
-        <h2 className={settingSectionTitleStyle}>通知</h2>
-        <div className={settingItemListStyle}>
-          <div className={settingItemStyle}>
-            <input
-              type="checkbox"
-              id="notify-review-requested"
-              onChange={onChangeNotifyReviewRequested}
-              defaultChecked={settings.notifyReviewRequested}
-            />
-            <label
-              htmlFor="notify-review-requested"
-              className={settingItemLabelStyle}
-            >
-              レビューリクエスト時に通知を受け取る
-            </label>
+const Settings: FC<SettingsProps> = React.memo(
+  ({
+    settings,
+    onChangeNotifyReviewRequested,
+    onChangeShowsRequestedReviewPr,
+    onChangedShowsInReviewPr,
+    onChangedShowsApprovedPr,
+    onClickDeleteRepository,
+  }) => {
+    const [isOpenModal, setIsOpenModal] = useState(false);
+
+    return (
+      <>
+        <div className={settingSectionStyle}>
+          <h2 className={settingSectionTitleStyle}>通知</h2>
+          <div className={settingItemListStyle}>
+            <div className={settingItemStyle}>
+              <input
+                type="checkbox"
+                id="notify-review-requested"
+                onChange={onChangeNotifyReviewRequested}
+                defaultChecked={settings.notifyReviewRequested}
+              />
+              <label
+                htmlFor="notify-review-requested"
+                className={settingItemLabelStyle}
+              >
+                レビューリクエスト時に通知を受け取る
+              </label>
+            </div>
           </div>
         </div>
-      </div>
-      <div className={settingSectionStyle}>
-        <h2 className={settingSectionTitleStyle}>PRの表示</h2>
-        <div className={settingItemListStyle}>
-          <div className={settingItemStyle}>
-            <input
-              type="checkbox"
-              id="shows-requested-review-pr"
-              onChange={onChangeShowsRequestedReviewPr}
-              defaultChecked={settings.showsRequestedReviewPR}
-            />
-            <label
-              htmlFor="shows-requested-review-pr"
-              className={settingItemLabelStyle}
-            >
-              レビュー待ちのPRを表示
-            </label>
-          </div>
-          <div className={settingItemStyle}>
-            <input
-              type="checkbox"
-              id="shows-in-review-pr"
-              onChange={onChangedShowsInReviewPr}
-              defaultChecked={settings.showsInReviewPR}
-            />
-            <label
-              htmlFor="shows-in-review-pr"
-              className={settingItemLabelStyle}
-            >
-              レビュー中のPRを表示
-            </label>
-          </div>
-          <div className={settingItemStyle}>
-            <input
-              type="checkbox"
-              id="shows-approved-pr"
-              onChange={onChangedShowsApprovedPr}
-              defaultChecked={settings.showsApprovedPR}
-            />
-            <label
-              htmlFor="shows-approved-pr"
-              className={settingItemLabelStyle}
-            >
-              承認済みのPRを表示
-            </label>
+        <div className={settingSectionStyle}>
+          <h2 className={settingSectionTitleStyle}>PRの表示</h2>
+          <div className={settingItemListStyle}>
+            <div className={settingItemStyle}>
+              <input
+                type="checkbox"
+                id="shows-requested-review-pr"
+                onChange={onChangeShowsRequestedReviewPr}
+                defaultChecked={settings.showsRequestedReviewPR}
+              />
+              <label
+                htmlFor="shows-requested-review-pr"
+                className={settingItemLabelStyle}
+              >
+                レビュー待ちのPRを表示
+              </label>
+            </div>
+            <div className={settingItemStyle}>
+              <input
+                type="checkbox"
+                id="shows-in-review-pr"
+                onChange={onChangedShowsInReviewPr}
+                defaultChecked={settings.showsInReviewPR}
+              />
+              <label
+                htmlFor="shows-in-review-pr"
+                className={settingItemLabelStyle}
+              >
+                レビュー中のPRを表示
+              </label>
+            </div>
+            <div className={settingItemStyle}>
+              <input
+                type="checkbox"
+                id="shows-approved-pr"
+                onChange={onChangedShowsApprovedPr}
+                defaultChecked={settings.showsApprovedPR}
+              />
+              <label
+                htmlFor="shows-approved-pr"
+                className={settingItemLabelStyle}
+              >
+                承認済みのPRを表示
+              </label>
+            </div>
           </div>
         </div>
-      </div>
-      <div className={settingSectionStyle}>
-        <h2 className={settingSectionTitleStyle}>リポジトリ一覧</h2>
-        {settings.subscribedRepositories.map((repository) => (
-          <div className={repositoryListItemStyle} key={repository}>
-            <span>{repository}</span>
+        <div className={settingSectionStyle}>
+          <h2 className={settingSectionTitleStyle}>リポジトリ一覧</h2>
+          <div className={`${settingItemListStyle} ${repositoryListStyle}`}>
+            {settings.subscribedRepositories.map((repository) => (
+              <div className={repositoryListItemStyle} key={repository}>
+                <span className={ellipsisStyle}>{repository}</span>
+                <button
+                  aria-label="リポジトリを削除"
+                  onClick={() => onClickDeleteRepository(repository)}
+                  className={deleteButtonStyle}
+                >
+                  <XCircleFillIcon className={deleteIconStyle} size={16} />
+                </button>
+              </div>
+            ))}
             <button
-              aria-label="リポジトリを削除"
-              onClick={() => onClickDeleteRepository(repository)}
+              onClick={() => {
+                setIsOpenModal(true);
+              }}
+              className={addRepositoryStyle}
             >
-              <XCircleFillIcon className={deleteIconStyle} size={16} />
+              + 追加
             </button>
+            <SelectRepositoryModal
+              isOpen={isOpenModal}
+              onClose={() => setIsOpenModal(false)}
+            />
           </div>
-        ))}
-        <Link to="/select-repository">+ 追加</Link>
-      </div>
-    </>
-  );
-};
+        </div>
+      </>
+    );
+  }
+);
 
 export const SettingsContainer = () => {
   const {

--- a/renderer/src/containers/SettingsContainer/style.css.ts
+++ b/renderer/src/containers/SettingsContainer/style.css.ts
@@ -27,16 +27,44 @@ export const settingItemLabelStyle = style({
   marginLeft: space(1),
 });
 
+export const repositoryListStyle = style({
+  maxWidth: 200,
+});
+
 export const repositoryListItemStyle = style({
   display: 'flex',
   alignItems: 'center',
+  justifyContent: 'space-between',
   gap: space(1),
   lineHeight: 1.5,
+  fontSize: '1.4rem',
+  selectors: {
+    '&:last-of-type': {
+      marginBottom: 4,
+    },
+  },
+});
+
+export const ellipsisStyle = style({
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+});
+
+export const deleteButtonStyle = style({
+  display: 'inline-flex',
 });
 
 export const deleteIconStyle = style({
   color: themeVars.color.red,
   ':hover': {
     cursor: 'pointer',
+    opacity: 0.8,
+  },
+});
+
+export const addRepositoryStyle = style({
+  ':hover': {
+    opacity: 0.8,
   },
 });

--- a/renderer/src/layouts/BaseLayout/BaseLayout.tsx
+++ b/renderer/src/layouts/BaseLayout/BaseLayout.tsx
@@ -8,8 +8,8 @@ interface Props {
 
 export const BaseLayout: React.FC<Props> = (props: Props) => {
   return (
-    <main className={`${rootStyle}`}>
-      <div className={`${navContainerStyle}`}>
+    <main className={rootStyle}>
+      <div className={navContainerStyle}>
         <LeftNav />
       </div>
       <div>{props.children}</div>

--- a/renderer/src/layouts/BaseLayout/styles.css.ts
+++ b/renderer/src/layouts/BaseLayout/styles.css.ts
@@ -15,5 +15,5 @@ export const navContainerStyle = style({
   top: '0',
   left: '0',
   height: '100vh',
-  zIndex: 100,
+  zIndex: 10,
 });

--- a/renderer/src/pages/SelectRepositoryPage/SelectRepositoryPage.tsx
+++ b/renderer/src/pages/SelectRepositoryPage/SelectRepositoryPage.tsx
@@ -1,32 +1,14 @@
-import React, { memo, useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
-import classNames from 'classnames';
-import { PlusCircleIcon, CheckCircleFillIcon } from '@primer/octicons-react';
-import { SearchRepository, Button } from '../../components';
+import { Button } from '../../components';
 import { useSettings } from '../../hooks';
 import { BaseLayout } from '../../layouts/BaseLayout';
-import {
-  completeButtonStyle,
-  containerStyle,
-  iconButtonStyle,
-  iconStyle,
-  repositoryLinkStyle,
-  repositoryListItemStyle,
-  repositoryListStyle,
-  titleStyle,
-} from './styles.css';
-import { themeFocusVisibleOutline } from '../../theme.css';
-import { Repository } from '../../hooks/useSearchRepository';
+import { completeButtonStyle, containerStyle, titleStyle } from './styles.css';
+import { SelectRepositoryContainer } from '../../containers/SelectRepositoryContainer/SelectRepositoryContainer';
 
 export const SelectRepositoryPage = () => {
   const history = useHistory();
-  const [repositories, setRepositories] = useState<Repository[]>([]);
-  const { settings, addSubscribedRepository, removeSubscribedRepository } =
-    useSettings();
-
-  const handleSearch = useCallback(async (repositories: Repository[]) => {
-    setRepositories(repositories);
-  }, []);
+  const { settings } = useSettings();
 
   const handleClick = useCallback(() => {
     if (settings.subscribedRepositories.length === 0) {
@@ -40,15 +22,7 @@ export const SelectRepositoryPage = () => {
     <BaseLayout>
       <div className={containerStyle}>
         <h1 className={titleStyle}>リポジトリを選択</h1>
-        <SearchRepository onSearch={handleSearch} />
-        {repositories.length > 0 && (
-          <RepositoryList
-            repositories={repositories}
-            subscribedRepositories={settings.subscribedRepositories}
-            addRepository={addSubscribedRepository}
-            removeRepository={removeSubscribedRepository}
-          />
-        )}
+        <SelectRepositoryContainer />
         <Button className={completeButtonStyle} onClick={handleClick}>
           完了
         </Button>
@@ -56,62 +30,3 @@ export const SelectRepositoryPage = () => {
     </BaseLayout>
   );
 };
-
-type RepositoryListProps = {
-  repositories: Repository[];
-  subscribedRepositories: string[];
-  addRepository: (repository: string) => void;
-  removeRepository: (repository: string) => void;
-};
-
-const RepositoryList = memo<RepositoryListProps>(
-  ({
-    repositories,
-    subscribedRepositories,
-    addRepository,
-    removeRepository,
-  }) => {
-    return (
-      <ul className={repositoryListStyle}>
-        {repositories.map((repository) => (
-          <li
-            key={repository.nameWithOwner}
-            className={repositoryListItemStyle}
-          >
-            <a
-              href={repository.url}
-              target="_blank"
-              rel="noopner noreferrer"
-              className={repositoryLinkStyle}
-            >
-              {repository.nameWithOwner}
-            </a>
-            {subscribedRepositories.includes(repository.nameWithOwner) ? (
-              <button
-                onClick={() => removeRepository(repository.nameWithOwner)}
-                className={classNames(
-                  iconButtonStyle,
-                  themeFocusVisibleOutline
-                )}
-                title={`${repository}を設定から削除する`}
-              >
-                <CheckCircleFillIcon className={iconStyle} size={24} />
-              </button>
-            ) : (
-              <button
-                onClick={() => addRepository(repository.nameWithOwner)}
-                className={classNames(
-                  iconButtonStyle,
-                  themeFocusVisibleOutline
-                )}
-                title={`${repository}を設定に追加する`}
-              >
-                <PlusCircleIcon className={iconStyle} size={24} />
-              </button>
-            )}
-          </li>
-        ))}
-      </ul>
-    );
-  }
-);

--- a/renderer/src/pages/SelectRepositoryPage/styles.css.ts
+++ b/renderer/src/pages/SelectRepositoryPage/styles.css.ts
@@ -9,39 +9,7 @@ export const containerStyle = style({
 export const titleStyle = style({
   paddingBottom: space(1),
   borderBottom: `1px solid ${themeVars.color.gray100}`,
-});
-
-export const repositoryListStyle = style({
-  marginTop: space(2),
-  fontSize: '1.4rem',
-});
-
-export const repositoryListItemStyle = style({
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-  padding: `${space(0.5)} 0`,
-  ':first-child': {
-    paddingTop: 0,
-  },
-});
-
-export const repositoryLinkStyle = style({
-  transition: 'opacity 0.1s ease-in',
-  width: '100%',
-  ':hover': {
-    opacity: 0.7,
-  },
-});
-
-export const iconButtonStyle = style({
-  ':hover': {
-    cursor: 'pointer',
-  },
-});
-
-export const iconStyle = style({
-  color: themeVars.color.green,
+  marginBottom: space(4),
 });
 
 export const completeButtonStyle = style({

--- a/renderer/src/theme.css.ts
+++ b/renderer/src/theme.css.ts
@@ -33,6 +33,8 @@ export const themeFocusVisibleOutline = style({
 
 globalStyle('html', {
   fontSize: '0.625rem', // 16px * 0.625 = 10px
+  fontFamily:
+    "'Helvetica Neue',Arial,'Hiragino Kaku Gothic ProN','Hiragino Sans',Meiryo,sans-serif",
 });
 
 globalStyle('body', {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
     "skipLibCheck": true, // @types/react がバージョン違いで Duplicate identifier が発生するので true に設定
-    "esModuleInterop": false,
+    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## やったこと
- リポジトリ選択モーダルの実装
  - リポジトリ選択のコンポーネントを共通コンポーネントして切り出た
  - ユニットテストの追加
- 初回時のリポジトリ選択画面をリファクタ
  - 共通コンポーネントを使うように修正
- アプリケーション全体の font-family の設定 

## 経緯
元々ページを再利用するために、リポジトリ追加はリポジトリ選択画面に遷移するようにしていた。
ただ、実際に操作をしていて戻るなどのページ遷移の実装の依存関係が嫌だったので、モーダルで表示するように変更した。