### PR TITLE
jestのカバレッジ取得を実行時に指定する形式に変更

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -20,7 +20,7 @@ jobs:
       - run: pnpm install
       - run: pnpm lint
       - run: pnpm type-check
-      - run: pnpm test
+      - run: pnpm test -- --coverage
       - name: Codecov
         uses: codecov/codecov-action@v2
         with:

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
     electron: '<rootDir>/electron/src/__mocks__/electron.ts',
     '\\.css$': 'identity-obj-proxy',
   },
-  collectCoverage: true,
+  collectCoverage: false,
   collectCoverageFrom: ['renderer/**/*.{ts,tsx}', 'electron/**/*.ts'],
   coverageProvider: 'v8',
 };

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "lint": "eslint . --cache --ext .js,.ts,.tsx",
     "prepare": "husky install",
     "format": "prettier --write \"**/*.{js,ts,tsx,json}\"",
-    "test:jest": "jest",
-    "test": "pnpm test:jest",
+    "test": "jest",
     "type-check": "pnpm type-check:renderer && pnpm type-check:electron",
     "type-check:renderer": "tsc --noEmit",
     "type-check:electron": "tsc -p tsconfig.electron.json --noEmit"


### PR DESCRIPTION
## やったこと
- jest.config.js でカバレッジの設定をfalseに変更
- CI実行時にカバレッジを有効にするように修正