### PR TITLE
設定リポジトリの一覧が未設定の時にプルリクのバッジ件数が1件以上になるバグの修正

### DIFF
--- a/renderer/src/lib/queryBuilder.spec.ts
+++ b/renderer/src/lib/queryBuilder.spec.ts
@@ -8,5 +8,11 @@ describe('queryBuilder', () => {
       expect(result).toEqual(expect.stringContaining('repo:test/repositoryA'));
       expect(result).toEqual(expect.stringContaining('repo:test/repositoryB'));
     });
+
+    it('リポジトリの一覧が空配列の時は空文字を返す', () => {
+      const repositories: string[] = [];
+      const result = buildSearchPullRequestsQuery(repositories);
+      expect(result).toBe('');
+    });
   });
 });

--- a/renderer/src/lib/queryBuilder.ts
+++ b/renderer/src/lib/queryBuilder.ts
@@ -1,5 +1,10 @@
-export const buildSearchPullRequestsQuery = (repositories: string[]) => `
-type:pr state:open involves:@me -author:@me ${repositories
-  .map((repo) => `repo:${repo}`)
-  .join(' ')}
-`;
+export const buildSearchPullRequestsQuery = (repositories: string[]) => {
+  if (repositories.length === 0) {
+    return '';
+  } else {
+    return `type:pr state:open involves:@me -author:@me ${repositories
+      .map((repo) => `repo:${repo}`)
+      .join(' ')}
+    `;
+  }
+};


### PR DESCRIPTION
close #119 

## バグの原因
配列の一覧が空の時に `type:pr state:open involves:@me -author:@me` のクエリ文字列が生成されており、自身が所属する全てのリポジトリが検索対象になってしまっていた。

## やったこと
- 検索クエリの生成ロジックを修正
	- 空配列の時は空文字を返す
