### PR TITLE
react-router を react-router-dom に置き換え

### DIFF
--- a/renderer/src/components/LeftNav/LeftNav.spec.tsx
+++ b/renderer/src/components/LeftNav/LeftNav.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { LeftNav } from '.';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter } from 'react-router-dom';
 import { usePullRequests } from '../../hooks';
 import { PullRequest } from '../../models';
 

--- a/renderer/src/components/LeftNav/LeftNav.tsx
+++ b/renderer/src/components/LeftNav/LeftNav.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useAtom } from 'jotai';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { loginUserAtom, signOutAtom } from '../../jotai';
 import { GitHubAvatar } from '../GitHubAvatar';
 import { UserMenu } from '../UserMenu';

--- a/renderer/src/components/UserMenu/UserMenu.spec.tsx
+++ b/renderer/src/components/UserMenu/UserMenu.spec.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { UserMenu } from './';
 import userEvent from '@testing-library/user-event';
 import { UserMenuProps } from '..';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter } from 'react-router-dom';
 
 describe('UserMenu', () => {
   const renderUserMenu = (props: Partial<UserMenuProps> | undefined) => {

--- a/renderer/src/containers/SettingsContainer/SettingsContainer.spec.tsx
+++ b/renderer/src/containers/SettingsContainer/SettingsContainer.spec.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { SettingsContainer } from './SettingContainer';
 import userEvent from '@testing-library/user-event';
 import { Settings } from '../../models';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter } from 'react-router-dom';
 
 const defaultSettings: Settings = {
   notifyReviewRequested: false,


### PR DESCRIPTION
## 概要
node_modules に存在しない react-router からモジュールを読み込んでいた不具合を修正した。