### PR TITLE
chore: GitHubのリリース作成を自動化

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: release
+
+on:
+  push:
+    branches:
+      - production
+
+jobs:
+  release:
+    runs-on: macos-11
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install dependencies
+        run: yarn install
+      - name: Build Application
+        run: yarn build
+        env:
+          GITHUB_APP_CLIENT_ID: ${{ secrets.PROD_GITHUB_APP_CLIENT_ID }}
+          GITHUB_APP_CLIENT_SECRET: ${{ secrets.PROD_GITHUB_APP_CLIENT_SECRET }}
+      - name: Get npm version
+        id: package-version
+        run: |
+          VERSION=$(node -pe "require('./package.json').version")
+          echo "::set-output name=current-version::$VERSION"
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        id: release
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: false
+          tag_name: v${{ steps.package-version.outputs.current-version }}
+          generate_release_notes: true
+          files: |
+            ./app/ReviewCat-${{ steps.package-version.outputs.current-version }}.dmg
+      - name: Notify to Slack
+        uses: 8398a7/action-slack@v3
+        with:
+          fields: repo,job
+          status: ${{ job.status }}
+          mention: channel
+          if_mentions: always
+          text: |
+            v${{ steps.package-version.outputs.current-version }} のリリース🎉
+            ${{ steps.release.outputs.url }}
+          author_name: ${{ github.actor }}
+          icon_emoji: ':octocat:'
+          username: review-cat-bot
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/build.js
+++ b/build.js
@@ -1,7 +1,9 @@
 const path = require('path');
-const { build } = require('electron-builder');
+const builder = require('electron-builder');
 
-build({
+builder.build({
+  targets: builder.Platform.MAC.createTarget(),
+  publish: 'never',
   config: {
     directories: {
       output: path.join(__dirname, 'app'),

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "vite:dev": "vite",
     "vite:build": "tsc && vite build",
     "electron:dev": "yarn electron:tsc && yarn electron:copy && NODE_ENV=development electron --require dotenv/config ./dist/app.js",
-    "electron:build": "yarn electron:tsc && yarn electron:copy && env-cmd -f \".env.production\" babel dist/src --out-dir dist/src && node build.js",
+    "electron:build": "yarn electron:tsc && yarn electron:copy && env-cmd --silent -f \".env.production\" babel dist/src --out-dir dist/src && node build.js",
     "electron:copy": "cpx 'electron/assets/images/**' dist/assets/images",
     "electron:tsc": "tsc -p tsconfig.electron.json",
     "clean:app": "rimraf app",


### PR DESCRIPTION
## やったこと
- GitHubのリリース作成を自動生成する GitHub Actions の作成
- electron-builder のターゲットをMacに指定
- electron-builder の publish 設定を追加

## リリースフロー
1. バージョンをアップデートするPRを作成してマージ
2. main => production へリリースPRを作成してマージ
3. リリースPRがマージ後
  3-1. リリースとタグが自動生成される
  3-2. Slackにリリース完了の通知が飛ぶ
