### PR TITLE
fix: macOS11.1でDockが非表示にならないバグ対応

### DIFF
--- a/build.js
+++ b/build.js
@@ -14,6 +14,9 @@ builder.build({
     files: ['./dist'],
     mac: {
       icon: 'dist/assets/images/app-icon.png',
+      extendInfo: {
+        LSUIElement: 'true',
+      },
     },
   },
 });


### PR DESCRIPTION
## 参考

https://togithub.com/maxogden/menubar/issues/306