### PR TITLE
feat: PRの一覧が更新された時に新しいPRをデスクトップ通知

### DIFF
--- a/renderer/src/jotai/pullRequest.ts
+++ b/renderer/src/jotai/pullRequest.ts
@@ -1,4 +1,5 @@
 import { atomWithReducer } from 'jotai/utils';
+import { notifyPullRequests } from '../lib/notification';
 import { PullRequest } from '../models';
 
 export const START_FETCH_ACTION = 'startFetchPullRequests' as const;
@@ -36,8 +37,13 @@ const pullRequestReducer = (prev: State, action: Action): State => {
       };
     }
     case UPDATE_ACTION: {
+      const newPullRequests = action.payload.pullRequests;
+      if (!prev.firstLoading) {
+        notifyPullRequests(newPullRequests, prev.pullRequests);
+      }
+
       return {
-        pullRequests: action.payload.pullRequests,
+        pullRequests: newPullRequests,
         firstLoading: false,
       };
     }

--- a/renderer/src/lib/notification.spec.ts
+++ b/renderer/src/lib/notification.spec.ts
@@ -1,0 +1,70 @@
+import { createPullRequest } from '../../../test/mocks/factory/pullRequest';
+import { PullRequest } from '../models';
+import { notifyPullRequests } from './notification';
+
+describe('lib/notification', () => {
+  const NotificationOriginal = window.Notification;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let NotificationMock: jest.MockedFunction<any>;
+
+  beforeEach(() => {
+    NotificationMock = jest.fn();
+    NotificationMock.permission = 'granted';
+    window.Notification = NotificationMock;
+  });
+
+  afterEach(() => {
+    window.Notification = NotificationOriginal;
+  });
+
+  it('新しい「レビュー待ち」のプルリクエストが存在したらデスクトップ通知をする', () => {
+    const newPullRequest = createPullRequest({
+      title: '新しいPR',
+      url: 'https://github.com/higeOhige/review-cat/pull/100',
+      status: 'requestedReview',
+    });
+    const beforePullRequests: PullRequest[] = [
+      createPullRequest({ status: 'reviewing' }),
+    ];
+    const newPullRequests = [...beforePullRequests, newPullRequest];
+    notifyPullRequests(newPullRequests, beforePullRequests);
+
+    expect(NotificationMock).toBeCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: `${newPullRequest.title}\n${newPullRequest.url}`,
+      })
+    );
+  });
+
+  it('更新後のプルリクエストが「レビュー待ち」に更新された時にデスクトップ通知をする', () => {
+    const pullRequest = createPullRequest();
+    const newPullRequests: PullRequest[] = [
+      { ...pullRequest, status: 'requestedReview' },
+    ];
+    const beforePullRequests: PullRequest[] = [
+      { ...pullRequest, status: 'reviewing' },
+    ];
+    notifyPullRequests(newPullRequests, beforePullRequests);
+
+    expect(NotificationMock).toBeCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: expect.any(String),
+      })
+    );
+  });
+
+  it('更新後のプルリクエストが「レビュー済み」の場合はデスクトップ通知をしない', () => {
+    const pullRequest = createPullRequest();
+    const newPullRequests: PullRequest[] = [
+      { ...pullRequest, status: 'approved' },
+    ];
+    const beforePullRequests: PullRequest[] = [
+      { ...pullRequest, status: 'reviewing' },
+    ];
+    notifyPullRequests(newPullRequests, beforePullRequests);
+
+    expect(NotificationMock).not.toBeCalled();
+  });
+});

--- a/renderer/src/lib/notification.ts
+++ b/renderer/src/lib/notification.ts
@@ -1,0 +1,44 @@
+import { PullRequest } from '../models';
+
+const shouldNotify = (
+  newPullRequest: PullRequest,
+  beforePullRequest?: PullRequest
+) => {
+  if (beforePullRequest == null) {
+    return newPullRequest.status === 'requestedReview';
+  } else {
+    return (
+      beforePullRequest.status !== newPullRequest.status &&
+      newPullRequest.status === 'requestedReview'
+    );
+  }
+};
+
+/**
+ * デスクトップ通知をする
+ * NOTE: ElectronではレンダラープロセスでHTML5のNotification APIを利用すると
+ *       プラットフォームのネイティブ通知が実行される。
+ *       許可などの管理もプラットフォームに依存するので、コード上での許可の確認は不要
+ * @param pullRequest
+ */
+const notifyPullRequest = (pullRequest: PullRequest) => {
+  new Notification('新着のレビューリクエスト', {
+    body: `${pullRequest.title}\n${pullRequest.url}`,
+    requireInteraction: true,
+  });
+};
+
+export const notifyPullRequests = (
+  newPullRequests: PullRequest[],
+  beforePullRequests: PullRequest[]
+) => {
+  for (const newPullRequest of newPullRequests) {
+    const beforePullRequest = beforePullRequests.find(
+      (pr) => pr.url === newPullRequest.url
+    );
+
+    if (shouldNotify(newPullRequest, beforePullRequest)) {
+      notifyPullRequest(newPullRequest);
+    }
+  }
+};

--- a/test/mocks/factory/pullRequest.ts
+++ b/test/mocks/factory/pullRequest.ts
@@ -1,0 +1,18 @@
+import { PullRequest } from '../../../renderer/src/models';
+import { createRepository } from './repository';
+import { createUser } from './user';
+
+export const createPullRequest = (pullRequest?: Partial<PullRequest>) => {
+  const defaultValue: PullRequest = {
+    title: 'テストPRです',
+    url: 'https://github.com/higeOhige/review-cat/pull/84',
+    author: createUser(),
+    repository: createRepository(),
+    status: 'requestedReview',
+  };
+
+  return {
+    ...defaultValue,
+    ...pullRequest,
+  };
+};

--- a/test/mocks/factory/repository.ts
+++ b/test/mocks/factory/repository.ts
@@ -1,0 +1,13 @@
+import { Repository } from '../../../renderer/src/models';
+
+export const createRepository = (repository?: Partial<Repository>) => {
+  const defaultValue: Repository = {
+    nameWithOwner: 'test/testA',
+    openGraphImageUrl: 'https://example.com/images/avatar.jpg',
+  };
+
+  return {
+    ...defaultValue,
+    ...repository,
+  };
+};

--- a/test/mocks/factory/user.ts
+++ b/test/mocks/factory/user.ts
@@ -1,0 +1,13 @@
+import { User } from '../../../renderer/src/models';
+
+export const createUser = (user?: Partial<User>) => {
+  const defaultValue: User = {
+    name: 'test',
+    avatarUrl: 'https://example.com/images/avatar.jpg',
+  };
+
+  return {
+    ...defaultValue,
+    ...user,
+  };
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "useUnknownInCatchVariables": true,
     "exactOptionalPropertyTypes": true
   },
-  "include": ["./renderer"]
+  "include": ["./renderer", "./test"]
 }


### PR DESCRIPTION
## やったこと
- 新着のレビューリクエストのPRをデスクトップ通知する機能を追加
- プルリクエストを監視するフックを微リファクタ
- 通知処理のユニットテストを追加
- モックデータ生成用のテストのヘルパー関数を追加