### PR TITLE
自分が作成したプルリクエストの対応を追加

### DIFF
--- a/packages/web/src/components/LeftNav/LeftNav.spec.tsx
+++ b/packages/web/src/components/LeftNav/LeftNav.spec.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { LeftNav } from '.';
 import { MemoryRouter } from 'react-router-dom';
 import { usePullRequests } from '../../hooks';
-import { PullRequest } from '../../models';
+import { PullRequest, pullRequestStatus } from '../../models';
 
 jest.mock('../../hooks/usePullRequests');
 const usePullRequestsMock = usePullRequests as jest.MockedFunction<
@@ -12,16 +12,16 @@ const usePullRequestsMock = usePullRequests as jest.MockedFunction<
 
 const defaultPullRequests = [
   {
-    status: 'requestedReview',
+    status: pullRequestStatus.waitingReview,
   },
   {
-    status: 'requestedReview',
+    status: pullRequestStatus.waitingReview,
   },
   {
-    status: 'reviewing',
+    status: pullRequestStatus.reviewed,
   },
   {
-    status: 'approved',
+    status: pullRequestStatus.approved,
   },
 ];
 

--- a/packages/web/src/components/LeftNav/LeftNav.tsx
+++ b/packages/web/src/components/LeftNav/LeftNav.tsx
@@ -14,6 +14,7 @@ import {
 import { GitPullRequestIcon } from '@primer/octicons-react';
 import { Link } from 'react-router-dom';
 import { usePullRequests } from '../../hooks';
+import { pullRequestStatus } from '../../models';
 
 export const LeftNav: React.FC = () => {
   const history = useHistory();
@@ -24,7 +25,7 @@ export const LeftNav: React.FC = () => {
   const { pullRequests, firstLoading } = usePullRequests();
 
   const requestedReviewPullRequests = pullRequests.filter(
-    (pr) => pr.status === 'requestedReview'
+    (pr) => pr.status === pullRequestStatus.waitingReview
   );
 
   useEffect(() => {

--- a/packages/web/src/components/PullRequestItem/PullRequestItem.spec.tsx
+++ b/packages/web/src/components/PullRequestItem/PullRequestItem.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { instance, mock, when } from 'ts-mockito';
 import { PullRequestItem } from '.';
-import { PullRequest, User } from '../../models';
+import { PullRequest, pullRequestStatus, User } from '../../models';
 
 describe('PullRequestItem', () => {
   describe('link', () => {
@@ -31,16 +31,16 @@ describe('PullRequestItem', () => {
   describe('status', () => {
     it.each([
       {
-        status: 'requestedReview' as const,
+        status: pullRequestStatus.waitingReview,
         expected: 'レビュー待ち',
       },
       {
-        status: 'reviewing' as const,
-        expected: 'レビュー中',
+        status: pullRequestStatus.reviewed,
+        expected: 'レビュー済み',
       },
       {
-        status: 'approved' as const,
-        expected: '承認済',
+        status: pullRequestStatus.approved,
+        expected: '承認済み',
       },
     ])('$status のときに $expected を表示する', ({ status, expected }) => {
       const authorMock = mock<User>();

--- a/packages/web/src/components/PullRequestItem/PullRequestItem.tsx
+++ b/packages/web/src/components/PullRequestItem/PullRequestItem.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import { PullRequest, PullRequestStatus } from '../../models';
+import {
+  PullRequest,
+  PullRequestStatus,
+  pullRequestStatus,
+} from '../../models';
 import { GitHubAvatar } from '../GitHubAvatar';
 import { styles } from './styles.css';
 
@@ -11,8 +15,8 @@ export const PullRequestItem: React.FC<Props> = ({ pullRequest }) => {
   const { author, url, title, status } = pullRequest;
 
   const statusLabel: { [key in PullRequestStatus]: string } = {
-    requestedReview: 'レビュー待ち',
-    reviewing: 'レビュー済み',
+    waitingReview: 'レビュー待ち',
+    reviewed: 'レビュー済み',
     approved: '承認済み',
   };
 

--- a/packages/web/src/components/PullRequestItem/PullRequestItem.tsx
+++ b/packages/web/src/components/PullRequestItem/PullRequestItem.tsx
@@ -12,8 +12,8 @@ export const PullRequestItem: React.FC<Props> = ({ pullRequest }) => {
 
   const statusLabel: { [key in PullRequestStatus]: string } = {
     requestedReview: 'レビュー待ち',
-    reviewing: 'レビュー中',
-    approved: '承認済',
+    reviewing: 'レビュー済み',
+    approved: '承認済み',
   };
 
   return (

--- a/packages/web/src/components/RepositorySection/RepositorySection.spec.tsx
+++ b/packages/web/src/components/RepositorySection/RepositorySection.spec.tsx
@@ -51,8 +51,8 @@ describe('RepositorySection', () => {
       const pullRequestItems = screen.getAllByRole('listitem');
 
       expect(pullRequestItems[0]).toHaveTextContent('レビュー待ち');
-      expect(pullRequestItems[1]).toHaveTextContent('レビュー中');
-      expect(pullRequestItems[2]).toHaveTextContent('承認済');
+      expect(pullRequestItems[1]).toHaveTextContent('レビュー済み');
+      expect(pullRequestItems[2]).toHaveTextContent('承認済み');
     });
   });
 });

--- a/packages/web/src/components/RepositorySection/RepositorySection.spec.tsx
+++ b/packages/web/src/components/RepositorySection/RepositorySection.spec.tsx
@@ -5,6 +5,7 @@ import { RepositorySection } from '.';
 import {
   PullRequest,
   PullRequestStatus,
+  pullRequestStatus,
   RepositoryData,
   User,
 } from '../../models';
@@ -34,9 +35,9 @@ describe('RepositorySection', () => {
   describe('sortPullRequests', () => {
     it('ステータスに応じてプルリクの一覧をソートする', () => {
       const pullRequests = [
-        'approved' as const,
-        'requestedReview' as const,
-        'reviewing' as const,
+        pullRequestStatus.approved,
+        pullRequestStatus.waitingReview,
+        pullRequestStatus.reviewed,
       ].map((status, i) => {
         const url = `https://github.com/higeOhige/review-cat/pull/${i}`;
         return createPullRequest({ status, url });

--- a/packages/web/src/components/RepositorySection/RepositorySection.tsx
+++ b/packages/web/src/components/RepositorySection/RepositorySection.tsx
@@ -15,8 +15,8 @@ interface Props {
 export const RepositorySection: React.FC<Props> = ({ repository }) => {
   const sortPullRequests = (pullRequests: PullRequest[]) => {
     const priority: { [key in PullRequestStatus]: number } = {
-      requestedReview: 1,
-      reviewing: 2,
+      waitingReview: 1,
+      reviewed: 2,
       approved: 3,
     };
 

--- a/packages/web/src/containers/PullRequestListContainer/PullRequestListContainer.spec.tsx
+++ b/packages/web/src/containers/PullRequestListContainer/PullRequestListContainer.spec.tsx
@@ -53,14 +53,6 @@ jest.mock('../../hooks/usePullRequests', () => {
 
 describe('PullRequestListContainer', () => {
   describe('filterPullRequests', () => {
-    // let settingsMock: Settings;
-    // let spyUseSettings: SpyUserSettings;
-
-    // beforeEach(() => {
-    //   // settingsMock = mock<Settings>();
-    //   // spyUseSettings = jest.spyOn(useSettingsHook, 'useSettings');
-    // });
-
     it.each([
       {
         statusText: 'レビュー待ち',
@@ -69,13 +61,13 @@ describe('PullRequestListContainer', () => {
         showsApprovedPR: true,
       },
       {
-        statusText: 'レビュー中',
+        statusText: 'レビュー済み',
         showsRequestedReviewPR: true,
         showsInReviewPR: false,
         showsApprovedPR: true,
       },
       {
-        statusText: '承認済',
+        statusText: '承認済み',
         showsRequestedReviewPR: true,
         showsInReviewPR: true,
         showsApprovedPR: false,
@@ -97,20 +89,20 @@ describe('PullRequestListContainer', () => {
 
         render(<PullRequestListContainer />);
 
-        const requestedReviewPullRequest = screen.queryByText('レビュー待ち');
-        const reviewingPullRequest = screen.queryByText('レビュー中');
-        const approvedPullRequest = screen.queryByText('承認済');
+        const waitingReviewPullRequest = screen.queryByText('レビュー待ち');
+        const reviewedPullRequest = screen.queryByText('レビュー済み');
+        const approvedPullRequest = screen.queryByText('承認済み');
 
         if (cases.showsRequestedReviewPR) {
-          expect(requestedReviewPullRequest).toBeInTheDocument();
+          expect(waitingReviewPullRequest).toBeInTheDocument();
         } else {
-          expect(requestedReviewPullRequest).not.toBeInTheDocument();
+          expect(waitingReviewPullRequest).not.toBeInTheDocument();
         }
 
         if (cases.showsInReviewPR) {
-          expect(reviewingPullRequest).toBeInTheDocument();
+          expect(reviewedPullRequest).toBeInTheDocument();
         } else {
-          expect(reviewingPullRequest).not.toBeInTheDocument();
+          expect(reviewedPullRequest).not.toBeInTheDocument();
         }
 
         if (cases.showsApprovedPR) {

--- a/packages/web/src/containers/PullRequestListContainer/PullRequestListContainer.spec.tsx
+++ b/packages/web/src/containers/PullRequestListContainer/PullRequestListContainer.spec.tsx
@@ -4,6 +4,7 @@ import { instance, mock, when } from 'ts-mockito';
 import {
   PullRequest,
   PullRequestStatus,
+  pullRequestStatus,
   Repository,
   Settings,
   User,
@@ -21,9 +22,9 @@ jest.mock('../../hooks/useSettings', () => {
 
 jest.mock('../../hooks/usePullRequests', () => {
   const pullRequests = [
-    'requestedReview' as const,
-    'reviewing' as const,
-    'approved' as const,
+    pullRequestStatus.waitingReview,
+    pullRequestStatus.reviewed,
+    pullRequestStatus.approved,
   ].map((status: PullRequestStatus) => {
     const repositoryMock = mock<Repository>();
     when(repositoryMock.nameWithOwner).thenReturn('test');

--- a/packages/web/src/containers/PullRequestListContainer/PullRequestListContainer.tsx
+++ b/packages/web/src/containers/PullRequestListContainer/PullRequestListContainer.tsx
@@ -1,9 +1,14 @@
 import React, { FC } from 'react';
 import { usePullRequests } from '../../hooks/usePullRequests';
 import { RepositorySection } from '../../components/RepositorySection';
-import { PullRequest, Repositories, Settings, User } from '../../models';
+import {
+  PullRequest,
+  pullRequestStatus,
+  Repositories,
+  Settings,
+  User,
+} from '../../models';
 import { useSettings } from '../../hooks';
-import { useGitHubAccounts } from '../../hooks/useGitHubAccounts';
 import { useAtom } from 'jotai';
 import { loginUserAtom } from '../../jotai';
 
@@ -52,11 +57,11 @@ const filterPullRequests = (
     }
 
     switch (pr.status) {
-      case 'requestedReview':
+      case pullRequestStatus.waitingReview:
         return settings.showsRequestedReviewPR;
-      case 'reviewing':
+      case pullRequestStatus.reviewed:
         return settings.showsInReviewPR;
-      case 'approved':
+      case pullRequestStatus.approved:
         return settings.showsApprovedPR;
       default:
     }

--- a/packages/web/src/containers/SettingsContainer/SettingContainer.tsx
+++ b/packages/web/src/containers/SettingsContainer/SettingContainer.tsx
@@ -25,6 +25,7 @@ type SettingsProps = {
   ) => void;
   onChangedShowsInReviewPr: (event: ChangeEvent<HTMLInputElement>) => void;
   onChangedShowsApprovedPr: (event: ChangeEvent<HTMLInputElement>) => void;
+  onChangeShowsMyPr: (event: ChangeEvent<HTMLInputElement>) => void;
   onChangeAutoLaunch: (event: ChangeEvent<HTMLInputElement>) => void;
   onClickDeleteRepository: (repository: string) => void;
 };
@@ -36,6 +37,7 @@ const Settings: FC<SettingsProps> = React.memo(
     onChangeShowsRequestedReviewPr,
     onChangedShowsInReviewPr,
     onChangedShowsApprovedPr,
+    onChangeShowsMyPr,
     onChangeAutoLaunch,
     onClickDeleteRepository,
   }) => {
@@ -105,6 +107,17 @@ const Settings: FC<SettingsProps> = React.memo(
                 className={settingItemLabelStyle}
               >
                 承認済みのPRを表示
+              </label>
+            </div>
+            <div className={settingItemStyle}>
+              <input
+                type="checkbox"
+                id="shows-my-pr"
+                onChange={onChangeShowsMyPr}
+                defaultChecked={settings.showsMyPR}
+              />
+              <label htmlFor="shows-my-pr" className={settingItemLabelStyle}>
+                自分が作成したPRを表示
               </label>
             </div>
           </div>
@@ -184,6 +197,12 @@ export const SettingsContainer = () => {
     });
   };
 
+  const handleShowsMyPr = (event: ChangeEvent<HTMLInputElement>) => {
+    updateShowsPR({
+      mine: event.target.checked,
+    });
+  };
+
   const handleChangeAutoLaunch = (event: ChangeEvent<HTMLInputElement>) => {
     updateAutoLaunch(event.target.checked);
   };
@@ -201,6 +220,7 @@ export const SettingsContainer = () => {
       onChangeShowsRequestedReviewPr={handleShowsRequestedReview}
       onChangedShowsInReviewPr={handleShowsInReview}
       onChangedShowsApprovedPr={handleShowsApproved}
+      onChangeShowsMyPr={handleShowsMyPr}
       onChangeAutoLaunch={handleChangeAutoLaunch}
       onClickDeleteRepository={removeSubscribedRepository}
     />

--- a/packages/web/src/containers/SettingsContainer/SettingsContainer.spec.tsx
+++ b/packages/web/src/containers/SettingsContainer/SettingsContainer.spec.tsx
@@ -10,6 +10,7 @@ const defaultSettings: Settings = {
   showsRequestedReviewPR: true,
   showsInReviewPR: true,
   showsApprovedPR: true,
+  showsMyPR: true,
   autoLaunched: false,
   subscribedRepositories: ['test/testA', 'test/testB'],
 };

--- a/packages/web/src/hooks/useSettings.ts
+++ b/packages/web/src/hooks/useSettings.ts
@@ -22,10 +22,12 @@ export const useSettings = () => {
       requestedReview = settings.showsRequestedReviewPR,
       inReview = settings.showsInReviewPR,
       approved = settings.showsApprovedPR,
+      mine = settings.showsMyPR,
     }: {
       requestedReview?: boolean;
       inReview?: boolean;
       approved?: boolean;
+      mine?: boolean;
     }) => {
       dispatch({
         type: UPDATE_ACTION,
@@ -33,6 +35,7 @@ export const useSettings = () => {
           showsRequestedReviewPR: requestedReview,
           showsInReviewPR: inReview,
           showsApprovedPR: approved,
+          showsMyPR: mine,
         },
       });
     },

--- a/packages/web/src/hooks/useWatchPullRequests.spec.ts
+++ b/packages/web/src/hooks/useWatchPullRequests.spec.ts
@@ -23,6 +23,9 @@ describe('usePullRequestStatus', () => {
         totalCount: 1,
         nodes: [{ requestedReviewer: { login: userName } }],
       });
+      when(mockPullRequest.reviews).thenReturn({
+        nodes: [],
+      });
 
       const status = getPullRequestStatus(
         instance(mockPullRequest),
@@ -53,6 +56,10 @@ describe('usePullRequestStatus', () => {
     });
 
     it('上記以外の場合はプルリクエストをレビュー済みの状態にする', () => {
+      when(mockPullRequest.reviews).thenReturn({
+        nodes: [],
+      });
+
       const status = getPullRequestStatus(
         instance(mockPullRequest),
         instance(mockUser)

--- a/packages/web/src/hooks/useWatchPullRequests.ts
+++ b/packages/web/src/hooks/useWatchPullRequests.ts
@@ -215,10 +215,11 @@ export const useWatchPullRequests = () => {
 
   const onResponse = useCallback(
     (result: ApolloQueryResult<SearchPullRequestsQueryResponse>) => {
+      if (loginUser == null) return;
       const pullRequests = parseQueryResponse(result.data);
-      dispatch({ type: UPDATE_ACTION, payload: { pullRequests } });
+      dispatch({ type: UPDATE_ACTION, payload: { loginUser, pullRequests } });
     },
-    [dispatch, parseQueryResponse]
+    [dispatch, loginUser, parseQueryResponse]
   );
 
   const startPolling = useCallback(

--- a/packages/web/src/jotai/pullRequest.ts
+++ b/packages/web/src/jotai/pullRequest.ts
@@ -1,6 +1,6 @@
 import { atomWithReducer } from 'jotai/utils';
 import { notifyPullRequests } from '../lib/notification';
-import { PullRequest } from '../models';
+import { PullRequest, User } from '../models';
 
 export const START_FETCH_ACTION = 'startFetchPullRequests' as const;
 export const UPDATE_ACTION = 'updatePullRequests' as const;
@@ -12,6 +12,7 @@ type StartFetchAction = {
 type UpdateAction = {
   type: typeof UPDATE_ACTION;
   payload: {
+    loginUser: User;
     pullRequests: PullRequest[];
   };
 };
@@ -37,9 +38,10 @@ const pullRequestReducer = (prev: State, action: Action): State => {
       };
     }
     case UPDATE_ACTION: {
+      const loginUser = action.payload.loginUser;
       const newPullRequests = action.payload.pullRequests;
       if (!prev.firstLoading) {
-        notifyPullRequests(newPullRequests, prev.pullRequests);
+        notifyPullRequests(loginUser, newPullRequests, prev.pullRequests);
       }
 
       return {

--- a/packages/web/src/jotai/settings.spec.ts
+++ b/packages/web/src/jotai/settings.spec.ts
@@ -48,6 +48,8 @@ describe('jotai/settings', () => {
         subscribedRepositories: ['test/test1', 'test/test2'],
       };
 
+      // TODO: 単体で実行した時にテストに失敗する
+      //       getSettingsのモックが更新されていない
       mockStorage.getSettings.mockReturnValue(savedSettings);
 
       const { result } = renderHook(() => useAtom(settingsReducerAtom));

--- a/packages/web/src/jotai/settings.spec.ts
+++ b/packages/web/src/jotai/settings.spec.ts
@@ -1,8 +1,8 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useAtom } from 'jotai';
 import { Settings } from '../models';
-import { settingsReducerAtom, UPDATE_ACTION } from './settings';
 import { storage } from '../lib/storage';
+import { settingsReducerAtom, UPDATE_ACTION } from './settings';
 
 jest.mock('../lib/storage');
 const mockStorage = storage as jest.Mocked<typeof storage>;
@@ -21,6 +21,7 @@ describe('jotai/settings', () => {
         showsRequestedReviewPR: true,
         showsInReviewPR: true,
         showsApprovedPR: false,
+        showsMyPR: false,
         autoLaunched: false,
         subscribedRepositories: ['test/test1', 'test/test2'],
       };
@@ -42,9 +43,11 @@ describe('jotai/settings', () => {
         showsRequestedReviewPR: true,
         showsInReviewPR: true,
         showsApprovedPR: false,
+        showsMyPR: false,
         autoLaunched: false,
         subscribedRepositories: ['test/test1', 'test/test2'],
       };
+
       mockStorage.getSettings.mockReturnValue(savedSettings);
 
       const { result } = renderHook(() => useAtom(settingsReducerAtom));

--- a/packages/web/src/jotai/settings.ts
+++ b/packages/web/src/jotai/settings.ts
@@ -16,11 +16,15 @@ const defaultSettings: Settings = {
   showsRequestedReviewPR: true,
   showsInReviewPR: true,
   showsApprovedPR: true,
+  showsMyPR: true,
   autoLaunched: false,
   subscribedRepositories: [],
 };
 
-const initialSettings = storage.getSettings() ?? defaultSettings;
+const initialSettings = {
+  ...defaultSettings,
+  ...storage.getSettings(),
+};
 
 const settingsReducer = (prev: Settings, action: SettingsAction) => {
   switch (action.type) {

--- a/packages/web/src/lib/notification.spec.ts
+++ b/packages/web/src/lib/notification.spec.ts
@@ -1,5 +1,5 @@
 import { createPullRequest } from '../../test/mocks/factory/pullRequest';
-import { PullRequest } from '../models';
+import { PullRequest, pullRequestStatus } from '../models';
 import { notifyPullRequests } from './notification';
 
 describe('lib/notification', () => {
@@ -21,10 +21,10 @@ describe('lib/notification', () => {
     const newPullRequest = createPullRequest({
       title: '新しいPR',
       url: 'https://github.com/higeOhige/review-cat/pull/100',
-      status: 'requestedReview',
+      status: pullRequestStatus.waitingReview,
     });
     const beforePullRequests: PullRequest[] = [
-      createPullRequest({ status: 'reviewing' }),
+      createPullRequest({ status: pullRequestStatus.reviewed }),
     ];
     const newPullRequests = [...beforePullRequests, newPullRequest];
     notifyPullRequests(newPullRequests, beforePullRequests);
@@ -40,10 +40,10 @@ describe('lib/notification', () => {
   it('更新後のプルリクエストが「レビュー待ち」に更新された時にデスクトップ通知をする', () => {
     const pullRequest = createPullRequest();
     const newPullRequests: PullRequest[] = [
-      { ...pullRequest, status: 'requestedReview' },
+      { ...pullRequest, status: pullRequestStatus.waitingReview },
     ];
     const beforePullRequests: PullRequest[] = [
-      { ...pullRequest, status: 'reviewing' },
+      { ...pullRequest, status: pullRequestStatus.reviewed },
     ];
     notifyPullRequests(newPullRequests, beforePullRequests);
 
@@ -58,13 +58,17 @@ describe('lib/notification', () => {
   it('更新後のプルリクエストが「レビュー済み」の場合はデスクトップ通知をしない', () => {
     const pullRequest = createPullRequest();
     const newPullRequests: PullRequest[] = [
-      { ...pullRequest, status: 'approved' },
+      { ...pullRequest, status: pullRequestStatus.approved },
     ];
     const beforePullRequests: PullRequest[] = [
-      { ...pullRequest, status: 'reviewing' },
+      { ...pullRequest, status: pullRequestStatus.reviewed },
     ];
     notifyPullRequests(newPullRequests, beforePullRequests);
 
     expect(NotificationMock).not.toBeCalled();
   });
+
+  it.todo(
+    '自分が作成したプルリクエストの場合は「レビュー済み」になった時にデスクトップ通知する'
+  );
 });

--- a/packages/web/src/lib/notification.ts
+++ b/packages/web/src/lib/notification.ts
@@ -1,15 +1,16 @@
-import { PullRequest } from '../models';
+import { PullRequest, pullRequestStatus } from '../models';
 
 const shouldNotify = (
   newPullRequest: PullRequest,
   beforePullRequest?: PullRequest
 ) => {
+  // TODO: 自分が作成したプルリクエストの場合はレビュー済みになった状態で通知する
   if (beforePullRequest == null) {
-    return newPullRequest.status === 'requestedReview';
+    return newPullRequest.status === pullRequestStatus.waitingReview;
   } else {
     return (
       beforePullRequest.status !== newPullRequest.status &&
-      newPullRequest.status === 'requestedReview'
+      newPullRequest.status === pullRequestStatus.waitingReview
     );
   }
 };

--- a/packages/web/src/lib/notification.ts
+++ b/packages/web/src/lib/notification.ts
@@ -1,18 +1,28 @@
-import { PullRequest, pullRequestStatus } from '../models';
+import { PullRequest, pullRequestStatus, User } from '../models';
 
 const shouldNotify = (
+  loginUser: User,
   newPullRequest: PullRequest,
   beforePullRequest?: PullRequest
 ) => {
-  // TODO: 自分が作成したプルリクエストの場合はレビュー済みになった状態で通知する
+  // 自分が作成したプルリクエストの場合はレビュー済みになった状態で通知する
+  if (
+    newPullRequest.author.name === loginUser.name &&
+    newPullRequest.status === pullRequestStatus.reviewed
+  ) {
+    return true;
+  }
+
   if (beforePullRequest == null) {
     return newPullRequest.status === pullRequestStatus.waitingReview;
-  } else {
-    return (
-      beforePullRequest.status !== newPullRequest.status &&
-      newPullRequest.status === pullRequestStatus.waitingReview
-    );
+  } else if (
+    beforePullRequest.status !== newPullRequest.status &&
+    newPullRequest.status === pullRequestStatus.waitingReview
+  ) {
+    return true;
   }
+
+  return false;
 };
 
 /**
@@ -30,6 +40,7 @@ const notifyPullRequest = (pullRequest: PullRequest) => {
 };
 
 export const notifyPullRequests = (
+  loginUser: User,
   newPullRequests: PullRequest[],
   beforePullRequests: PullRequest[]
 ) => {
@@ -38,7 +49,7 @@ export const notifyPullRequests = (
       (pr) => pr.url === newPullRequest.url
     );
 
-    if (shouldNotify(newPullRequest, beforePullRequest)) {
+    if (shouldNotify(loginUser, newPullRequest, beforePullRequest)) {
       notifyPullRequest(newPullRequest);
     }
   }

--- a/packages/web/src/lib/queryBuilder.ts
+++ b/packages/web/src/lib/queryBuilder.ts
@@ -2,7 +2,7 @@ export const buildSearchPullRequestsQuery = (repositories: string[]) => {
   if (repositories.length === 0) {
     return '';
   } else {
-    return `type:pr state:open involves:@me -author:@me ${repositories
+    return `type:pr state:open involves:@me ${repositories
       .map((repo) => `repo:${repo}`)
       .join(' ')}
     `;

--- a/packages/web/src/lib/storage.spec.ts
+++ b/packages/web/src/lib/storage.spec.ts
@@ -66,6 +66,7 @@ describe('lib/storage', () => {
       showsRequestedReviewPR: true,
       showsInReviewPR: true,
       showsApprovedPR: true,
+      showsMyPR: true,
       autoLaunched: false,
       subscribedRepositories: ['test/test'],
     };

--- a/packages/web/src/models/PullRequest.ts
+++ b/packages/web/src/models/PullRequest.ts
@@ -5,7 +5,14 @@ export interface Repository {
   openGraphImageUrl: string;
 }
 
-export type PullRequestStatus = 'requestedReview' | 'reviewing' | 'approved';
+export const pullRequestStatus = {
+  waitingReview: 'waitingReview',
+  reviewed: 'reviewed',
+  approved: 'approved',
+} as const;
+
+export type PullRequestStatus =
+  (typeof pullRequestStatus)[keyof typeof pullRequestStatus];
 
 export interface PullRequest {
   title: string;

--- a/packages/web/src/models/Settings.ts
+++ b/packages/web/src/models/Settings.ts
@@ -3,6 +3,7 @@ export interface Settings {
   showsRequestedReviewPR: boolean;
   showsInReviewPR: boolean;
   showsApprovedPR: boolean;
+  showsMyPR: boolean;
   autoLaunched: boolean;
   subscribedRepositories: string[];
 }

--- a/packages/web/test/mocks/factory/pullRequest.ts
+++ b/packages/web/test/mocks/factory/pullRequest.ts
@@ -1,6 +1,6 @@
 import { createRepository } from './repository';
 import { createUser } from './user';
-import type { PullRequest } from '../../../src/models';
+import { PullRequest, pullRequestStatus } from '../../../src/models';
 
 export const createPullRequest = (pullRequest?: Partial<PullRequest>) => {
   const defaultValue: PullRequest = {
@@ -8,7 +8,7 @@ export const createPullRequest = (pullRequest?: Partial<PullRequest>) => {
     url: 'https://github.com/higeOhige/review-cat/pull/84',
     author: createUser(),
     repository: createRepository(),
-    status: 'requestedReview',
+    status: pullRequestStatus.waitingReview,
   };
 
   return {

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -10,6 +10,9 @@ export default defineConfig(({ mode }) => ({
   define: {
     __DEV__: false,
   },
+  server: {
+    port: 3000,
+  },
   build: {
     outDir: path.join(__dirname, 'dist'),
     emptyOutDir: true,


### PR DESCRIPTION
close #165 

## やったこと
- dev環境の起動ポートを3000に変更
- レビュー済みのラベルを「レビュー中」=>「レビュー済み」に変更
- 承認済みのラベルを「承認済」=>「承認済み」に変更
- 自分が作成したプルリクを一覧に表示
- 自分が作成したプルリクの表示設定を追加
- 自分が作成したプルリクがレビュー済みになった時にデスクトップ通知する機能を実装