### PR TITLE
リリース自動化のワークフローを変更

### DIFF
--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -1,0 +1,53 @@
+name: create_release_pr
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-version:
+        description: 'select release semantic version (patch, minor, major)'
+        required: true
+        type: choice
+        options:
+          - 'patch'
+          - 'minor'
+          - 'major'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      # アップデート後のバージョンを環境変数にセット
+      - name: Get new version
+        id: new-version
+        run: |
+          echo "NEW_VERSION=$(npm --no-git-tag-version version $RELEASE_TYPE)" >> $GITHUB_ENV
+
+      # package.jsonのバージョンをアップデートしてコミット
+      - name: Update package.json version
+        run: |
+          NEW_VERSION=$(npm --no-git-tag-version version ${{ env.RELEASE_VERSION }})
+          git add package.json
+          git commit -m "chore: release $NEW_VERSION"
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.release-version }}
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v5
+        with:
+          branch: release/v${{ env.NEW_VERSION }}
+          title: release ${{ env.NEW_VERSION }}
+          labels: release
+
+      - name: Enable Pull Request Automerge
+        run: gh pr merge --merge --auto "${{ steps.cpr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,17 @@
 name: release
 
 on:
-  workflow_dispatch:
-    inputs:
-      release-typ:
-        description: 'select release type (patch, minor, major)'
-        required: true
-        type: choice
-        options:
-          - 'patch'
-          - 'minor'
-          - 'major'
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
 
 jobs:
   release:
     runs-on: macos-latest
+    # releaseラベルが付いているPRがマージされたときに実行
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -48,35 +45,18 @@ jobs:
       - name: Package app
         run: yarn package
 
-      # gitを設定
-      - name: Git configuration
+      - name: set new version
         run: |
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "GitHub Actions"
+          NEW_VERSION=$(node -pe "require('./package.json').version")
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
 
-      # アップデート後のバージョンを環境変数にセット
-      - name: Get new version
+      # アップデート後のバージョンのタグを生成してプッシュ
+      - name: push new version tag
         id: new-version
         run: |
-          echo "NEW_VERSION=$(npm --no-git-tag-version version $RELEASE_TYPE)" >> $GITHUB_ENV
-        env:
-          RELEASE_TYPE: ${{ github.event.inputs.release-typ }}
-
-      # package.jsonのバージョンをアップデートしてコミット
-      - name: Update package.json version
-        run: |
-          git add package.json
-          git commit -m "chore: release ${{ env.NEW_VERSION }}"
-          git tag ${{ env.NEW_VERSION }}
-        env:
-          RELEASE_TYPE: ${{ github.event.inputs.release-typ }}
-
-      # 変更をリポジトリにプッシュ
-      - name: Push changes to repository
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git push origin && git push --tags
+          TAG_NAME="v${{ env.NEW_VERSION }}"
+          git tag $TAG_NAME
+          git push origin $TAG_NAME
 
       # リリースノートを生成して最新バージョンのアプリケーションを添付
       - name: Release


### PR DESCRIPTION
## 対応背景
- ブランチ保護の影響でpackage.jsonの更新を一度のGitHub Actionで解決するのが難しかった
- リリース用のPRを自動生成 => マージして自動リリース という流れを取るようにする

## やったこと
- リリース自動化のワークフローを変更