### PR TITLE
fix: サインアウト時に設定を削除しないように修正

### DIFF
--- a/packages/web/src/stores/auth/useAuth.ts
+++ b/packages/web/src/stores/auth/useAuth.ts
@@ -42,7 +42,6 @@ export const useAuth = () => {
     (callback?: () => void) => {
       removeToken();
       setUser(null);
-      storage.removeSettings();
 
       if (callback != null) {
         callback();


### PR DESCRIPTION
## 概要

サインアウト時に `storage.removeSettings()` を呼び出して設定を削除していたが、この処理を削除した。

サインアウトしても設定（リポジトリ設定など）を保持することで、再サインイン後にユーザーが再設定する手間を省く。

## 変更内容

- `useAuth.ts` の `signOut` 関数から `storage.removeSettings()` の呼び出しを削除

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)