### PR TITLE
chore: translate Japanese to English

### DIFF
--- a/packages/e2e/playwright/helpers/electron.ts
+++ b/packages/e2e/playwright/helpers/electron.ts
@@ -1,18 +1,18 @@
 import { _electron as electron } from 'playwright';
 
 export const launchElectronApp = async () => {
-  // アプリを起動
+  // Launch the app
   const electronApp = await electron.launch({
     args: [require.resolve('main/dist/app.js')],
   });
 
-  // メインプロセスのログを出力
+  // Output main process logs
   const mainProcess = electronApp.process();
   mainProcess.stdout?.on('data', (data) => {
     console.log(data.toString());
   });
 
-  // ウィンドウのコンソールログを出力
+  // Output window console logs
   const mainWindow = await electronApp.firstWindow();
   mainWindow.on('console', console.log);
 

--- a/packages/e2e/playwright/helpers/login.ts
+++ b/packages/e2e/playwright/helpers/login.ts
@@ -8,32 +8,32 @@ export const loginWithGitHub = async (
   server: MockServer,
   setting?: { [key: string]: any }
 ) => {
-  // ウィンドウのコンソールログを出力
+  // Output window console logs
   const mainWindow = await electronApp.firstWindow();
 
   await mainWindow.evaluate((setting) => {
-    // ログイン状態を初期化
+    // Initialize login state
     window.localStorage.clear();
 
     if (setting) {
       window.localStorage.setItem('settings', JSON.stringify(setting));
     }
 
-    // react-routerのページ遷移を実行するために、ナビゲーションのイベントを発火
+    // Fire navigation event to execute react-router page transition
     window.history.pushState({}, '', '/');
   }, setting);
 
-  // ログインボタンをクリック
+  // Click login button
   const loginButton = await mainWindow.getByRole('button', {
     name: 'Login To GitHub',
   });
   await loginButton.click();
 
-  // 認証用のウィンドウを取得
+  // Get authentication window
   const authWindow = await electronApp.waitForEvent('window');
   await authWindow.waitForLoadState('domcontentloaded');
 
-  // GitHub認証のページ遷移をモック
+  // Mock GitHub authentication page transition
   await authWindow.route('https://github.com/authorized', (route) => {
     return route.fulfill({
       status: 302,
@@ -41,7 +41,7 @@ export const loginWithGitHub = async (
     });
   });
 
-  // GitHub認証のアクセストークン取得をモック
+  // Mock GitHub authentication access token retrieval
   server.post('/login/oauth/access_token', (req, res) => {
     if (req.body.code === '1234567890') {
       return res.status(200).json({
@@ -52,7 +52,7 @@ export const loginWithGitHub = async (
     }
   });
 
-  // ユーザー情報の取得をモック
+  // Mock user information retrieval
   mockGitHubGraphQL({
     page: mainWindow,
     operation: 'LoginUser',
@@ -65,15 +65,15 @@ export const loginWithGitHub = async (
     },
   });
 
-  // ユーザーがGitHubでのログインを完了した状態を再現
+  // Reproduce the state where the user has completed login with GitHub
   try {
     await authWindow.goto('https://github.com/authorized', {
       waitUntil: 'commit',
     });
   } catch (error) {
-    // アプリケーションの仕様として、認証後にリダイレクトされたURLから認証コードを取得したらウィンドウが閉じられる
-    // ERROR_ABORTEDは正常な動作なので、エラーとして扱わない
-    // それ以外のエラーは異常な動作なので、エラーとして扱う
+    // As per application specification, the window is closed after retrieving the auth code from the redirected URL post-authentication
+    // ERROR_ABORTED is normal behavior, so do not treat it as an error
+    // Other errors are abnormal behavior, so treat them as errors
     if (!error.message.includes('net::ERR_ABORTED')) {
       throw error;
     }

--- a/packages/e2e/playwright/helpers/wait.ts
+++ b/packages/e2e/playwright/helpers/wait.ts
@@ -1,7 +1,7 @@
 import { type Page } from 'playwright';
 
 /**
- * ページ内の全ての画像が描画されるのを待つ
+ * Wait for all images on the page to be rendered
  * @param page
  * @returns
  */

--- a/packages/e2e/playwright/home.spec.ts
+++ b/packages/e2e/playwright/home.spec.ts
@@ -7,7 +7,7 @@ import { createSearchPullRequest } from './mock/graphql/pullRequest';
 import { server } from './mock/server';
 import { loginUser } from './mock/user';
 
-test.describe('ホーム画面', () => {
+test.describe('Home screen', () => {
   test.beforeAll(() => {
     server.listen();
   });
@@ -16,11 +16,11 @@ test.describe('ホーム画面', () => {
     server.close();
   });
 
-  test('ログインユーザーがレビュアーとなっているプルリクエスト一覧を表示', async ({}, testInfo) => {
+  test('Displays list of pull requests where the logged-in user is a reviewer', async ({}, testInfo) => {
     const electronApp = await launchElectronApp();
     const mainWindow = await electronApp.firstWindow();
 
-    // プルリクエスト一覧を取得するGraphQLのリクエストをモックする
+    // Mock the GraphQL request to fetch the pull request list
     const anotherUser = {
       login: 'test',
       avatarUrl:
@@ -32,12 +32,12 @@ test.describe('ホーム画面', () => {
       response: {
         body: {
           search: {
-            // 自分がレビュアーとなっているプルリクエスト
+            // Pull requests where self is a reviewer
             nodes: [
-              // レビュー待ち
+              // Waiting for review
               createSearchPullRequest({
                 headRefName: 'test/demo-1',
-                title: 'レビュー待ちのプルリクエスト',
+                title: 'Waiting for review pull request',
                 url: 'https://github.com/t-yng/review-cat/pull/84',
                 author: anotherUser,
                 repository: {
@@ -57,10 +57,10 @@ test.describe('ホーム画面', () => {
                   ],
                 },
               }),
-              // レビュー済み
+              // Reviewed
               createSearchPullRequest({
                 headRefName: 'test/demo-2',
-                title: 'レビュー済みのプルリクエスト',
+                title: 'Reviewed pull request',
                 url: 'https://github.com/t-yng/review-cat/pull/85',
                 author: anotherUser,
                 repository: {
@@ -84,10 +84,10 @@ test.describe('ホーム画面', () => {
                   nodes: [],
                 },
               }),
-              // 承認済み
+              // Approved
               createSearchPullRequest({
                 headRefName: 'test/demo-3',
-                title: '承認済みのプルリクエスト',
+                title: 'Approved pull request',
                 url: 'https://github.com/t-yng/review-cat/pull/86',
                 author: anotherUser,
                 repository: {
@@ -124,42 +124,42 @@ test.describe('ホーム画面', () => {
       },
     });
 
-    // ログインする
+    // Log in
     await loginWithGitHub(electronApp, server, {
       subscribedRepositories: ['t-yng/review-cat'],
     });
 
     await mainWindow.waitForURL('http://localhost:3000/');
-    // 画像の読み込みを待つ
+    // Wait for images to load
     await waitForRenderedImages(mainWindow);
 
     await expect(
-      mainWindow.getByText('レビュー待ちのプルリクエスト')
+      mainWindow.getByText('Waiting for review pull request')
     ).toBeVisible();
     await expect(
-      mainWindow.getByText('レビュー待ち', { exact: true })
+      mainWindow.getByText('Waiting for review', { exact: true })
     ).toBeVisible();
     await expect(
-      mainWindow.getByText('レビュー済みのプルリクエスト')
+      mainWindow.getByText('Reviewed pull request')
     ).toBeVisible();
     await expect(
-      mainWindow.getByText('レビュー済み', { exact: true })
+      mainWindow.getByText('Reviewed', { exact: true })
     ).toBeVisible();
     await expect(
-      mainWindow.getByText('承認済みのプルリクエスト')
+      mainWindow.getByText('Approved pull request')
     ).toBeVisible();
     await expect(
-      mainWindow.getByText('承認済み', { exact: true })
+      mainWindow.getByText('Approved', { exact: true })
     ).toBeVisible();
 
     await expect(mainWindow).toHaveScreenshot(`${testInfo.title}.png`);
   });
 
-  test('ログインユーザーが作成したプルリクエストの一覧を表示', async ({}, testInfo) => {
+  test('Displays list of pull requests created by the logged-in user', async ({}, testInfo) => {
     const electronApp = await launchElectronApp();
     const mainWindow = await electronApp.firstWindow();
 
-    // プルリクエスト一覧を取得するGraphQLのリクエストをモックする
+    // Mock the GraphQL request to fetch the pull request list
     const anotherAuthor = {
       login: 'test',
       avatarUrl:
@@ -171,12 +171,12 @@ test.describe('ホーム画面', () => {
       response: {
         body: {
           search: {
-            // ログインユーザーが作成したプルリクエスト
+            // Pull requests created by the logged-in user
             nodes: [
-              // レビュー待ち
+              // Waiting for review
               createSearchPullRequest({
                 headRefName: 'test/demo-1',
-                title: 'レビュー待ちのプルリクエスト',
+                title: 'Waiting for review pull request',
                 url: 'https://github.com/t-yng/review-cat/pull/84',
                 author: loginUser,
                 repository: {
@@ -196,10 +196,10 @@ test.describe('ホーム画面', () => {
                   ],
                 },
               }),
-              // レビュー済み
+              // Reviewed
               createSearchPullRequest({
                 headRefName: 'test/demo-2',
-                title: 'レビュー済みのプルリクエスト',
+                title: 'Reviewed pull request',
                 url: 'https://github.com/t-yng/review-cat/pull/85',
                 author: loginUser,
                 repository: {
@@ -224,10 +224,10 @@ test.describe('ホーム画面', () => {
                   nodes: [],
                 },
               }),
-              // 承認済み
+              // Approved
               createSearchPullRequest({
                 headRefName: 'test/demo-3',
-                title: '承認済みのプルリクエスト',
+                title: 'Approved pull request',
                 url: 'https://github.com/t-yng/review-cat/pull/86',
                 author: loginUser,
                 repository: {
@@ -265,32 +265,32 @@ test.describe('ホーム画面', () => {
       },
     });
 
-    // ログインする
+    // Log in
     await loginWithGitHub(electronApp, server, {
       subscribedRepositories: ['t-yng/review-cat'],
     });
 
     await mainWindow.waitForURL('http://localhost:3000/');
-    // 画像の読み込みを待つ
+    // Wait for images to load
     await waitForRenderedImages(mainWindow);
 
     await expect(
-      mainWindow.getByText('レビュー待ちのプルリクエスト')
+      mainWindow.getByText('Waiting for review pull request')
     ).toBeVisible();
     await expect(
-      mainWindow.getByText('レビュー待ち', { exact: true })
+      mainWindow.getByText('Waiting for review', { exact: true })
     ).toBeVisible();
     await expect(
-      mainWindow.getByText('レビュー済みのプルリクエスト')
+      mainWindow.getByText('Reviewed pull request')
     ).toBeVisible();
     await expect(
-      mainWindow.getByText('レビュー済み', { exact: true })
+      mainWindow.getByText('Reviewed', { exact: true })
     ).toBeVisible();
     await expect(
-      mainWindow.getByText('承認済みのプルリクエスト')
+      mainWindow.getByText('Approved pull request')
     ).toBeVisible();
     await expect(
-      mainWindow.getByText('承認済み', { exact: true })
+      mainWindow.getByText('Approved', { exact: true })
     ).toBeVisible();
 
     await expect(mainWindow).toHaveScreenshot(`${testInfo.title}.png`);

--- a/packages/e2e/playwright/login.spec.ts
+++ b/packages/e2e/playwright/login.spec.ts
@@ -4,7 +4,7 @@ import { loginWithGitHub } from './helpers/login';
 import { server } from './mock/server';
 import { loginUser } from './mock/user';
 
-test.describe('ログイン', () => {
+test.describe('Login', () => {
   test.beforeAll(() => {
     server.listen();
   });
@@ -14,14 +14,14 @@ test.describe('ログイン', () => {
     console.log('close server');
   });
 
-  test('GitHubでログインできる', async () => {
-    // アプリを起動
+  test('Can log in with GitHub', async () => {
+    // Launch the app
     const electronApp = await launchElectronApp();
 
-    // GitHubログイン
+    // GitHub login
     await loginWithGitHub(electronApp, server);
 
-    // ログインに成功してページ遷移が行われていることを確認
+    // Confirm that login succeeded and page navigation occurred
     const mainWindow = await electronApp.firstWindow();
     await expect(
       mainWindow.getByRole('img', { name: loginUser.login })

--- a/packages/e2e/playwright/mock/graphql.ts
+++ b/packages/e2e/playwright/mock/graphql.ts
@@ -33,7 +33,7 @@ export const mockGitHubGraphQL = ({
               }),
       });
     } else {
-      // 指定したoperationが含まれない場合はリクエストを後続に流す
+      // Pass the request through if the specified operation is not included
       route.fallback();
     }
   });
@@ -53,9 +53,9 @@ const getMutationOperationName = (query: string): string => {
 };
 
 /**
- * クエリに指定したoperationNameが含まれるか判定する
- * @param query GraphQLクエリ
- * @param operationName 判定対象のoperationName
+ * Determine if the specified operationName is included in the query
+ * @param query GraphQL query
+ * @param operationName The operationName to check
  * @returns
  */
 const hasOperationName = (query: string, operationName: string) => {

--- a/packages/e2e/playwright/mock/graphql/pullRequest.ts
+++ b/packages/e2e/playwright/mock/graphql/pullRequest.ts
@@ -40,10 +40,10 @@ export const createSearchPullRequest = (
   pullRequest?: Partial<SearchPullRequest>
 ) => {
   const defaultValue = {
-    // __typenameの値が無いとApolloで空オブジェクトになる
+    // Without a __typename value, Apollo returns an empty object
     __typename: 'PullRequest',
     headRefName: 'feat/tauri',
-    title: 'フレームワークをElectronからTauriへ移行',
+    title: 'Migrate framework from Electron to Tauri',
     url: 'https://github.com/t-yng/review-cat/pull/159',
     reviewDecision: null,
     author: {

--- a/packages/e2e/playwright/mock/graphql/server.ts
+++ b/packages/e2e/playwright/mock/graphql/server.ts
@@ -33,7 +33,7 @@ export const mockGitHubGraphQL = ({
               }),
       });
     } else {
-      // 指定したoperationが含まれない場合はリクエストを後続に流す
+      // Pass the request through if the specified operation is not included
       route.fallback();
     }
   });
@@ -53,9 +53,9 @@ const getMutationOperationName = (query: string): string => {
 };
 
 /**
- * クエリに指定したoperationNameが含まれるか判定する
- * @param query GraphQLクエリ
- * @param operationName 判定対象のoperationName
+ * Determine if the specified operationName is included in the query
+ * @param query GraphQL query
+ * @param operationName The operationName to check
  * @returns
  */
 const hasOperationName = (query: string, operationName: string) => {

--- a/packages/main/esbuild.js
+++ b/packages/main/esbuild.js
@@ -6,7 +6,7 @@ if (process.env.NODE_ENV === 'development') {
 
 require('esbuild').build({
   bundle: true,
-  // NOTE: electronをバンドルすると実行パスチェックでエラーが発生するので、バンドルしない
+  // NOTE: Bundling electron causes an error in the execution path check, so it is not bundled
   packages: 'external',
   entryPoints: ['src/app.ts', 'src/preload.ts'],
   outdir: 'dist',

--- a/packages/main/src/app.ts
+++ b/packages/main/src/app.ts
@@ -47,7 +47,7 @@ const menubarApp = menubar({
 });
 
 const hideDockIcon = () => {
-  // menubar の showDockIcon:false が正常に動作しないので、自前でドックアイコンを非表示にしている
+  // menubar's showDockIcon:false does not work properly, so dock icon is hidden manually
   // @see: https://github.com/maxogden/menubar/issues/306
   if (app.dock && app.dock.hide) {
     app.dock.hide();
@@ -71,10 +71,10 @@ menubarApp.on('ready', () => {
 });
 
 menubarApp.on('after-create-window', () => {
-  // 外部リンクに遷移するときに新しいウィンドウを表示せずにデフォルトのブラウザで表示する
+  // When navigating to external links, open in the default browser without showing a new window
   menubarApp.window?.webContents.setWindowOpenHandler(({ url }) => {
-    // NOTE: 外部リンクを開く時にウィンドウを閉じないようにブラウザにフォーカスを当てないようにする
-    //       ただし、Chromeの場合はバグでフォーカスが当たってしまうので注意
+    // NOTE: To prevent the window from closing when opening external links, do not focus the browser
+    //       However, note that Chrome has a bug where focus is applied
     // @see: vhttps://github.com/electron/electron/issues/12492
     if (url.startsWith('https:')) {
       shell.openExternal(url, { activate: false });

--- a/packages/main/src/lib/auth.spec.ts
+++ b/packages/main/src/lib/auth.spec.ts
@@ -10,7 +10,7 @@ describe('auth', () => {
       loadUrlSpy.mockReset();
     });
 
-    it('GithubのOAuth認証画面を表示すること', () => {
+    it('Displays the GitHub OAuth authentication screen', () => {
       auth.loginWithGithub(oAuthOptions);
       expect(loadUrlSpy).toHaveBeenCalled();
       expect(loadUrlSpy).toHaveBeenCalledWith(
@@ -18,7 +18,7 @@ describe('auth', () => {
       );
     });
 
-    it('認証後のリダイレクトURLから code を取得できること', async () => {
+    it('Can retrieve the code from the redirect URL after authentication', async () => {
       const code = '123456';
       jest
         .spyOn<WebContents, any>(new BrowserWindow().webContents, 'on')

--- a/packages/web/src/components/AccountSelect/AccountSelect.spec.tsx
+++ b/packages/web/src/components/AccountSelect/AccountSelect.spec.tsx
@@ -17,7 +17,7 @@ const renderAccountSelect = (_props?: Partial<AccountSelectProps>) => {
 };
 
 describe('AccountSelect', () => {
-  it('セレクトボックスをクリックしたときにアカウントの一覧が表示されること', async () => {
+  it('Account list is displayed when select box is clicked', async () => {
     const accounts = ['test1', 'test2'];
     const { container } = renderAccountSelect({ accounts });
 
@@ -29,14 +29,14 @@ describe('AccountSelect', () => {
   });
 
   describe('accounts', () => {
-    it('配列先頭のアカウントを初期表示すること', () => {
+    it('Initially displays the first account in the array', () => {
       const accounts = ['test1', 'test2'];
       renderAccountSelect({ accounts });
 
       expect(screen.queryByText(accounts[0])).toBeInTheDocument();
     });
 
-    it('一覧のアカウントを選択したときに選択中のアカウントを変更すること', async () => {
+    it('Changes the selected account when an account is selected from the list', async () => {
       const accounts = ['test1', 'test2'];
       const onSelectMock = jest.fn();
       const { container } = renderAccountSelect({
@@ -48,8 +48,8 @@ describe('AccountSelect', () => {
         async () => await ClickButton.play({ canvasElement: container })
       );
 
-      // NOTE: js-dom環境で実行するとボタンクリックでDOMの更新が行われないため、↑でボタンクリックを実行する
-      //       @headlessui/reactのも問題かもしれない
+      // NOTE: In js-dom environment, DOM updates don't occur on button click, so execute button click above
+      //       This may also be an issue with @headlessui/react
       await act(
         async () => await ClickAnotherAccount.play({ canvasElement: container })
       );

--- a/packages/web/src/components/AccountSelect/AccountSelect.tsx
+++ b/packages/web/src/components/AccountSelect/AccountSelect.tsx
@@ -22,8 +22,8 @@ export const AccountSelect: FC<AccountSelectProps> = memo(
   ({ accounts, onSelect }) => {
     const [selectedAccount, setSelectedAccount] = useState(accounts[0]);
 
-    // NOTE: useStateの初期値は最初のレンダリングの時だけ反映される
-    //       propsが更新されたタイミングでは初期値は反映されない
+    // NOTE: The initial value of useState is only applied on the first render
+    //       The initial value is not applied when props are updated
     useEffect(() => {
       setSelectedAccount(accounts[0]);
     }, [accounts]);

--- a/packages/web/src/components/AppIcon/AppIcon.tsx
+++ b/packages/web/src/components/AppIcon/AppIcon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
 
 export const AppIcon: React.FC = () => {
-  return <img src="/assets/logo.svg" alt="review-cat のロゴ" />;
+  return <img src="/assets/logo.svg" alt="review-cat logo" />;
 };

--- a/packages/web/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/web/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -28,7 +28,7 @@ export class ErrorBoundary extends Component<Props, State> {
     if (this.state.hasError) {
       return (
         <div style={{ padding: 16, color: 'red' }}>
-          <strong>エラーが発生しました:</strong>
+          <strong>An error occurred:</strong>
           <pre style={{ marginTop: 8, fontSize: 12, whiteSpace: 'pre-wrap' }}>
             {this.state.error?.message}
           </pre>

--- a/packages/web/src/components/GitHubAvatar/GitHubAvatar.spec.tsx
+++ b/packages/web/src/components/GitHubAvatar/GitHubAvatar.spec.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { GitHubAvatar } from './GitHubAvatar';
 
 describe('GitHubUserAvatar', () => {
-  it('alt props が無い場合は 空の alt 属性が指定される', () => {
+  it('Empty alt attribute is assigned when alt props are absent', () => {
     render(<GitHubAvatar src="#" />);
 
     expect(screen.getByAltText('')).toBeInTheDocument();

--- a/packages/web/src/components/GitHubAvatar/GitHubAvatar.tsx
+++ b/packages/web/src/components/GitHubAvatar/GitHubAvatar.tsx
@@ -7,7 +7,7 @@ interface Props extends React.ImgHTMLAttributes<HTMLImageElement> {
 
 export const GitHubAvatar: React.FC<Props> = memo(
   ({ alt = '', className = '', ...others }) => {
-    // TODO: GitHub のアバター画像、パラメータ(`s={size}`)でサイズ調整できるのでうまいこと利用したい。
+    // TODO: GitHub avatar images can be size-adjusted via parameter (`s={size}`) — would like to utilize this properly.
     return (
       <img className={`${rootStyle} ${className}`} alt={alt} {...others} />
     );

--- a/packages/web/src/components/LeftNav/LeftNav.spec.tsx
+++ b/packages/web/src/components/LeftNav/LeftNav.spec.tsx
@@ -40,23 +40,23 @@ describe('LeftNav', () => {
       return customRender(<LeftNav />);
     };
 
-    it('プルリク一覧へのリンクとなっている', () => {
+    it('Is a link to the pull request list', () => {
       renderLeftNav();
-      const pullRequestIcon = screen.getByLabelText('プルリクエスト一覧へ移動');
+      const pullRequestIcon = screen.getByLabelText('Go to pull request list');
       const link = pullRequestIcon.closest('a');
 
       expect(link).toBeInTheDocument();
       expect(link).toHaveAttribute('href', '/');
     });
 
-    it('レビューリクエストのプルリク数を表示する', () => {
+    it('Displays the number of review request pull requests', () => {
       renderLeftNav();
 
       const badge = screen.getByTestId('pr-count-badge');
       expect(badge).toHaveTextContent('2');
     });
 
-    it('リクエスト待ちのプルリクが0件の場合はバッジを表示しない', () => {
+    it('Does not display badge when there are 0 pending request pull requests', () => {
       usePullRequestsMock.mockReturnValue({
         pullRequests: [],
       });

--- a/packages/web/src/components/LeftNav/LeftNav.tsx
+++ b/packages/web/src/components/LeftNav/LeftNav.tsx
@@ -26,7 +26,7 @@ const PullRequestCountBadge: FC = () => {
 
   return (
     <span
-      aria-label={`PRが${requestedReviewPullRequests.length}個あります`}
+      aria-label={`There are ${requestedReviewPullRequests.length} PRs`}
       className={statusCountBadge}
       data-testid="pr-count-badge"
     >
@@ -84,7 +84,7 @@ export const LeftNav: FC = () => {
           <GitPullRequestIcon
             size={24}
             className={iconStyle}
-            aria-label="プルリクエスト一覧へ移動"
+            aria-label="Go to pull request list"
           />
           <Suspense fallback={null}>
             <PullRequestCountBadge />

--- a/packages/web/src/components/Loading/Loading.tsx
+++ b/packages/web/src/components/Loading/Loading.tsx
@@ -2,5 +2,5 @@ import { FC } from 'react';
 import { spinnerStyle } from './style.css';
 
 export const Loading: FC = () => {
-  return <div className={spinnerStyle} role="status" aria-label="読み込み中" />;
+  return <div className={spinnerStyle} role="status" aria-label="Loading" />;
 };

--- a/packages/web/src/components/PullRequestItem/PullRequestItem.spec.tsx
+++ b/packages/web/src/components/PullRequestItem/PullRequestItem.spec.tsx
@@ -6,7 +6,7 @@ import { PullRequest, pullRequestStatus, User } from '../../models';
 
 describe('PullRequestItem', () => {
   describe('link', () => {
-    it('リンク先がプルリクエストのURLになっている', () => {
+    it('Link destination is the pull request URL', () => {
       const authorMock = mock<User>();
       when(authorMock.avatarUrl).thenReturn(
         'https://example.com/images/avatar.jpg'
@@ -32,17 +32,17 @@ describe('PullRequestItem', () => {
     it.each([
       {
         status: pullRequestStatus.waitingReview,
-        expected: 'レビュー待ち',
+        expected: 'Waiting for review',
       },
       {
         status: pullRequestStatus.reviewed,
-        expected: 'レビュー済み',
+        expected: 'Reviewed',
       },
       {
         status: pullRequestStatus.approved,
-        expected: '承認済み',
+        expected: 'Approved',
       },
-    ])('$status のときに $expected を表示する', ({ status, expected }) => {
+    ])('Displays $expected when $status', ({ status, expected }) => {
       const authorMock = mock<User>();
       when(authorMock.avatarUrl).thenReturn(
         'https://example.com/images/avatar.jpg'

--- a/packages/web/src/components/PullRequestItem/PullRequestItem.tsx
+++ b/packages/web/src/components/PullRequestItem/PullRequestItem.tsx
@@ -15,9 +15,9 @@ export const PullRequestItem: React.FC<Props> = ({ pullRequest }) => {
   const { author, url, title, status } = pullRequest;
 
   const statusLabel: { [key in PullRequestStatus]: string } = {
-    waitingReview: 'レビュー待ち',
-    reviewed: 'レビュー済み',
-    approved: '承認済み',
+    waitingReview: 'Waiting for review',
+    reviewed: 'Reviewed',
+    approved: 'Approved',
   };
 
   return (

--- a/packages/web/src/components/RepositorySearchBox/RepositorySearchBox.spec.tsx
+++ b/packages/web/src/components/RepositorySearchBox/RepositorySearchBox.spec.tsx
@@ -6,7 +6,7 @@ describe('RepositorySearchBox', () => {
   const user = userEvent.setup();
 
   describe('onSearch', () => {
-    it('Enterを押した時に入力テキストを引数にして呼ばれること', async () => {
+    it('Called with input text as argument when Enter is pressed', async () => {
       const onSearchMock = jest.fn();
       render(<RepositorySearchBox onSearch={onSearchMock} />);
 

--- a/packages/web/src/components/RepositorySection/RepositorySection.spec.tsx
+++ b/packages/web/src/components/RepositorySection/RepositorySection.spec.tsx
@@ -33,7 +33,7 @@ describe('RepositorySection', () => {
   };
 
   describe('sortPullRequests', () => {
-    it('ステータスに応じてプルリクの一覧をソートする', () => {
+    it('Sorts the pull request list according to status', () => {
       const pullRequests = [
         pullRequestStatus.approved,
         pullRequestStatus.waitingReview,
@@ -50,9 +50,9 @@ describe('RepositorySection', () => {
       render(<RepositorySection repository={repository} />);
       const pullRequestItems = screen.getAllByRole('listitem');
 
-      expect(pullRequestItems[0]).toHaveTextContent('レビュー待ち');
-      expect(pullRequestItems[1]).toHaveTextContent('レビュー済み');
-      expect(pullRequestItems[2]).toHaveTextContent('承認済み');
+      expect(pullRequestItems[0]).toHaveTextContent('Waiting for review');
+      expect(pullRequestItems[1]).toHaveTextContent('Reviewed');
+      expect(pullRequestItems[2]).toHaveTextContent('Approved');
     });
   });
 });

--- a/packages/web/src/components/SearchRepository/SearchRepository.tsx
+++ b/packages/web/src/components/SearchRepository/SearchRepository.tsx
@@ -25,7 +25,7 @@ export const SearchRepository: FC<SearchRepositoryProps> = memo(
     const handleSearch = useCallback(
       async (keyword: string) => {
         if (account == null) {
-          alert('アカウントを選択してください');
+          alert('Please select an account');
           return;
         }
         const isOrganization = account !== user?.name;

--- a/packages/web/src/components/UserMenu/UserMenu.spec.tsx
+++ b/packages/web/src/components/UserMenu/UserMenu.spec.tsx
@@ -29,7 +29,7 @@ describe('UserMenu', () => {
     );
   };
 
-  it('ユーザー名を表示する', () => {
+  it('Displays the username', () => {
     const user = {
       avatarUrl: '',
       name: 'test',
@@ -41,19 +41,19 @@ describe('UserMenu', () => {
     expect(userName).toBeInTheDocument();
   });
 
-  it('設定画面へ遷移するリンクを表示する', () => {
+  it('Displays a link to navigate to the settings screen', () => {
     renderUserMenu(undefined);
-    const link = screen.getByText('設定').closest('a');
+    const link = screen.getByText('Settings').closest('a');
 
     expect(link).toHaveAttribute('href', '/settings');
   });
 
-  it('ログアウトがクリックされた時に、onClickSignOut を実行する', async () => {
+  it('Executes onClickSignOut when sign out is clicked', async () => {
     const handleClickSignOutMock = jest.fn();
 
     renderUserMenu({ onClickSignOut: handleClickSignOutMock });
 
-    const signOutButton = screen.getByText('ログアウト');
+    const signOutButton = screen.getByText('Sign out');
     await user.click(signOutButton);
 
     expect(handleClickSignOutMock).toBeCalled();

--- a/packages/web/src/components/UserMenu/UserMenu.tsx
+++ b/packages/web/src/components/UserMenu/UserMenu.tsx
@@ -22,14 +22,14 @@ export const UserMenu: FC<UserMenuProps> = memo(({ user, onClickSignOut }) => {
       <div className={`${listItemStyle} ${userNameStyle}`}>{user.name}</div>
       <Link to="/settings" className={`${listItemStyle} ${actionItemStyle}`}>
         <GearIcon className={actionIconStyle} />
-        <span className={actionLabelStyle}>設定</span>
+        <span className={actionLabelStyle}>Settings</span>
       </Link>
       <button
         className={`${listItemStyle} ${actionItemStyle}`}
         onClick={onClickSignOut}
       >
         <SignOutIcon className={actionIconStyle} />
-        <span className={actionLabelStyle}>ログアウト</span>
+        <span className={actionLabelStyle}>Sign out</span>
       </button>
     </div>
   );

--- a/packages/web/src/containers/PullRequestListContainer/PullRequestListContainer.spec.tsx
+++ b/packages/web/src/containers/PullRequestListContainer/PullRequestListContainer.spec.tsx
@@ -44,25 +44,25 @@ describe('PullRequestListContainer', () => {
   describe('filterPullRequests', () => {
     it.each([
       {
-        statusText: 'レビュー待ち',
+        statusText: 'Waiting for review',
         showsRequestedReviewPR: false,
         showsInReviewPR: true,
         showsApprovedPR: true,
       },
       {
-        statusText: 'レビュー済み',
+        statusText: 'Reviewed',
         showsRequestedReviewPR: true,
         showsInReviewPR: false,
         showsApprovedPR: true,
       },
       {
-        statusText: '承認済み',
+        statusText: 'Approved',
         showsRequestedReviewPR: true,
         showsInReviewPR: true,
         showsApprovedPR: false,
       },
     ])(
-      '$statusText の表示をOFFにした時にプルリクスト一覧から除外する',
+      'Excludes from the pull request list when display of $statusText is turned OFF',
       (cases) => {
         const setting = createSetting({
           showsRequestedReviewPR: cases.showsRequestedReviewPR,
@@ -74,9 +74,10 @@ describe('PullRequestListContainer', () => {
 
         customRender(<PullRequestListContainer />);
 
-        const waitingReviewPullRequest = screen.queryByText('レビュー待ち');
-        const reviewedPullRequest = screen.queryByText('レビュー済み');
-        const approvedPullRequest = screen.queryByText('承認済み');
+        const waitingReviewPullRequest =
+          screen.queryByText('Waiting for review');
+        const reviewedPullRequest = screen.queryByText('Reviewed');
+        const approvedPullRequest = screen.queryByText('Approved');
 
         if (cases.showsRequestedReviewPR) {
           expect(waitingReviewPullRequest).toBeInTheDocument();

--- a/packages/web/src/containers/PullRequestListContainer/PullRequestListContainer.tsx
+++ b/packages/web/src/containers/PullRequestListContainer/PullRequestListContainer.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/models';
 
 /**
- * プルリクエストをリポジトリ毎にまとめる
+ * Groups pull requests by repository
  */
 const groupByRepository = (pullRequests: Array<PullRequest>): Repositories => {
   return pullRequests.reduce(
@@ -48,7 +48,7 @@ const filterPullRequests = (
   loginUser: User | null
 ) => {
   return pullRequests.filter((pr) => {
-    // 自分のプルリクエストの表示設定がOFFの場合は自分のプルリクエストを除外
+    // If the display setting for own pull requests is OFF, exclude own pull requests
     if (pr.author.name === loginUser?.name && !settings.showsMyPR) {
       return false;
     }

--- a/packages/web/src/containers/SelectRepositoryContainer/SelectRepositoryContainer.spec.tsx
+++ b/packages/web/src/containers/SelectRepositoryContainer/SelectRepositoryContainer.spec.tsx
@@ -20,7 +20,7 @@ jest.mock('../../components/SearchRepository', () => ({
   SearchRepository: (props: any) => {
     return (
       <div>
-        <button onClick={() => props.onSearch(repositories)}>検索</button>
+        <button onClick={() => props.onSearch(repositories)}>Search</button>
         {props.children}
       </div>
     );
@@ -33,9 +33,9 @@ describe('SelectRepositoryContainer', () => {
     return customRender(<SelectRepositoryContainer />);
   };
 
-  it('検索結果のリポジトリ一覧を表示する', async () => {
+  it('Displays the repository list from search results', async () => {
     renderSelectRepositoryContainer();
-    const button = screen.getByText('検索');
+    const button = screen.getByText('Search');
 
     await act(async () => await user.click(button));
 

--- a/packages/web/src/containers/SelectRepositoryContainer/SelectRepositoryList.spec.tsx
+++ b/packages/web/src/containers/SelectRepositoryContainer/SelectRepositoryList.spec.tsx
@@ -29,7 +29,7 @@ describe('SelectRepositoryList', () => {
     return render(<SelectRepositoryList {...{ ...defaultProps, ...props }} />);
   };
 
-  it('リポジトリの一覧を表示する', () => {
+  it('Displays the repository list', () => {
     const repositories = [
       {
         nameWithOwner: 'test/testA',
@@ -47,8 +47,8 @@ describe('SelectRepositoryList', () => {
     }
   });
 
-  describe('リポジトリの追加', () => {
-    it('設定に未登録のリポジトリの場合は追加アイコンを表示する', () => {
+  describe('Repository addition', () => {
+    it('Displays add icon for repositories not registered in settings', () => {
       const repositories = [
         {
           nameWithOwner: 'test/testA',
@@ -58,14 +58,14 @@ describe('SelectRepositoryList', () => {
       renderSelectRepositoryList({ repositories, subscribedRepositories: [] });
 
       const addRepositoryButton = screen.getByRole('button', {
-        name: 'リポジトリを設定に追加する',
+        name: 'Add repository to settings',
       });
       const icon = queryByRole(addRepositoryButton, 'img', { hidden: true });
 
       expect(icon).toBeInTheDocument();
     });
 
-    it('追加アイコンをクリックすることでリポジトリを設定に追加するコールバック関数が呼ばれる', async () => {
+    it('Callback function to add repository to settings is called when add icon is clicked', async () => {
       const repositories = [
         {
           nameWithOwner: 'test/testA',
@@ -80,7 +80,7 @@ describe('SelectRepositoryList', () => {
       });
 
       const addRepositoryButton = screen.getByRole('button', {
-        name: 'リポジトリを設定に追加する',
+        name: 'Add repository to settings',
       });
       await user.click(addRepositoryButton);
 
@@ -88,8 +88,8 @@ describe('SelectRepositoryList', () => {
     });
   });
 
-  describe('リポジトリの削除', () => {
-    it('設定に登録済みのリポジトリは追加済みのアイコンを表示する', () => {
+  describe('Repository deletion', () => {
+    it('Displays already-added icon for repositories registered in settings', () => {
       const repositories = [
         {
           nameWithOwner: 'test/testA',
@@ -102,14 +102,14 @@ describe('SelectRepositoryList', () => {
       });
 
       const removeRepositoryButton = screen.getByRole('button', {
-        name: '設定からリポジトリを削除する',
+        name: 'Remove repository from settings',
       });
       const icon = queryByRole(removeRepositoryButton, 'img', { hidden: true });
 
       expect(icon).toBeInTheDocument();
     });
 
-    it('追加済みのアイコンをクリックすることでリポジトリを設定から削除するコールバック関数が呼ばれる', async () => {
+    it('Callback function to remove repository from settings is called when the already-added icon is clicked', async () => {
       const repositories = [
         {
           nameWithOwner: 'test/testA',
@@ -124,7 +124,7 @@ describe('SelectRepositoryList', () => {
       });
 
       const removeRepositoryButton = screen.getByRole('button', {
-        name: '設定からリポジトリを削除する',
+        name: 'Remove repository from settings',
       });
       await user.click(removeRepositoryButton);
 

--- a/packages/web/src/containers/SelectRepositoryContainer/SelectRepositoryList.tsx
+++ b/packages/web/src/containers/SelectRepositoryContainer/SelectRepositoryList.tsx
@@ -22,7 +22,7 @@ const AddRepositoryButton = memo<AddRepositoryButtonProps>(
       <button
         onClick={() => onClick(repository.nameWithOwner)}
         className={classNames(iconButtonStyle, themeFocusVisibleOutline)}
-        aria-label="リポジトリを設定に追加する"
+        aria-label="Add repository to settings"
       >
         <PlusCircleIcon className={iconStyle} size={24} />
       </button>
@@ -41,7 +41,7 @@ const DeleteRepositoryButton = memo<DeleteRepositoryButtonProps>(
       <button
         onClick={() => onClick(repository.nameWithOwner)}
         className={classNames(iconButtonStyle, themeFocusVisibleOutline)}
-        aria-label="設定からリポジトリを削除する"
+        aria-label="Remove repository from settings"
       >
         <CheckCircleFillIcon className={iconStyle} size={24} />
       </button>

--- a/packages/web/src/containers/SettingsContainer/SettingContainer.tsx
+++ b/packages/web/src/containers/SettingsContainer/SettingContainer.tsx
@@ -46,7 +46,7 @@ const Settings: FC<SettingsProps> = memo(
     return (
       <>
         <div className={settingSectionStyle}>
-          <h2 className={settingSectionTitleStyle}>通知</h2>
+          <h2 className={settingSectionTitleStyle}>Notifications</h2>
           <div className={settingItemListStyle}>
             <div className={settingItemStyle}>
               <input
@@ -59,13 +59,13 @@ const Settings: FC<SettingsProps> = memo(
                 htmlFor="notify-review-requested"
                 className={settingItemLabelStyle}
               >
-                レビューリクエスト時に通知を受け取る
+                Receive notifications for review requests
               </label>
             </div>
           </div>
         </div>
         <div className={settingSectionStyle}>
-          <h2 className={settingSectionTitleStyle}>PRの表示</h2>
+          <h2 className={settingSectionTitleStyle}>PR Display</h2>
           <div className={settingItemListStyle}>
             <div className={settingItemStyle}>
               <input
@@ -78,7 +78,7 @@ const Settings: FC<SettingsProps> = memo(
                 htmlFor="shows-requested-review-pr"
                 className={settingItemLabelStyle}
               >
-                レビュー待ちのPRを表示
+                Show waiting for review PRs
               </label>
             </div>
             <div className={settingItemStyle}>
@@ -92,7 +92,7 @@ const Settings: FC<SettingsProps> = memo(
                 htmlFor="shows-in-review-pr"
                 className={settingItemLabelStyle}
               >
-                レビュー中のPRを表示
+                Show in-review PRs
               </label>
             </div>
             <div className={settingItemStyle}>
@@ -106,7 +106,7 @@ const Settings: FC<SettingsProps> = memo(
                 htmlFor="shows-approved-pr"
                 className={settingItemLabelStyle}
               >
-                承認済みのPRを表示
+                Show approved PRs
               </label>
             </div>
             <div className={settingItemStyle}>
@@ -117,19 +117,19 @@ const Settings: FC<SettingsProps> = memo(
                 defaultChecked={settings.showsMyPR}
               />
               <label htmlFor="shows-my-pr" className={settingItemLabelStyle}>
-                自分が作成したPRを表示
+                Show PRs created by me
               </label>
             </div>
           </div>
         </div>
         <div className={settingSectionStyle}>
-          <h2 className={settingSectionTitleStyle}>リポジトリ一覧</h2>
+          <h2 className={settingSectionTitleStyle}>Repository list</h2>
           <div className={`${settingItemListStyle} ${repositoryListStyle}`}>
             {settings.subscribedRepositories.map((repository) => (
               <div className={repositoryListItemStyle} key={repository}>
                 <span className={ellipsisStyle}>{repository}</span>
                 <button
-                  aria-label="リポジトリを削除"
+                  aria-label="Delete repository"
                   onClick={() => onClickDeleteRepository(repository)}
                   className={deleteButtonStyle}
                 >
@@ -143,7 +143,7 @@ const Settings: FC<SettingsProps> = memo(
               }}
               className={addRepositoryStyle}
             >
-              + 追加
+              + Add
             </button>
             <SelectRepositoryModal
               isOpen={isOpenModal}
@@ -152,7 +152,7 @@ const Settings: FC<SettingsProps> = memo(
           </div>
         </div>
         <div className={settingSectionStyle}>
-          <h2 className={settingSectionTitleStyle}>起動</h2>
+          <h2 className={settingSectionTitleStyle}>Launch</h2>
           <div className={settingItemStyle}>
             <input
               type="checkbox"
@@ -161,7 +161,7 @@ const Settings: FC<SettingsProps> = memo(
               defaultChecked={settings.autoLaunched}
             />
             <label htmlFor="auto-launch" className={settingItemLabelStyle}>
-              ログイン時に自動で起動する
+              Launch automatically at login
             </label>
           </div>
         </div>

--- a/packages/web/src/containers/SettingsContainer/SettingsContainer.spec.tsx
+++ b/packages/web/src/containers/SettingsContainer/SettingsContainer.spec.tsx
@@ -45,12 +45,13 @@ describe('SettingsContainer', () => {
     return customRender(<SettingsContainer />);
   };
 
-  describe('通知設定', () => {
-    it('チェックボックスがクリックされた時にコールバック関数が呼ばれる', async () => {
+  describe('Notification settings', () => {
+    it('Callback function is called when checkbox is clicked', async () => {
       renderSettingContainer();
 
-      const checkbox =
-        screen.getByLabelText('レビューリクエスト時に通知を受け取る');
+      const checkbox = screen.getByLabelText(
+        'Receive notifications for review requests'
+      );
       await user.click(checkbox);
 
       expect(updateNotifyReviewRequestedMock).toBeCalledWith(
@@ -59,28 +60,28 @@ describe('SettingsContainer', () => {
     });
   });
 
-  describe('PR表示の設定', () => {
+  describe('PR display settings', () => {
     it.each([
       {
-        label: 'レビュー待ちのPRを表示',
+        label: 'Show waiting for review PRs',
         expected: {
           requestedReview: !defaultSettings.showsRequestedReviewPR,
         },
       },
       {
-        label: 'レビュー中のPRを表示',
+        label: 'Show in-review PRs',
         expected: {
           inReview: !defaultSettings.showsInReviewPR,
         },
       },
       {
-        label: '承認済みのPRを表示',
+        label: 'Show approved PRs',
         expected: {
           approved: !defaultSettings.showsApprovedPR,
         },
       },
     ])(
-      '$label のチェックボックスがクリックされた時にコールバック関数が呼ばれる',
+      'Callback function is called when $label checkbox is clicked',
       async ({ label, expected }) => {
         renderSettingContainer();
 
@@ -92,11 +93,11 @@ describe('SettingsContainer', () => {
     );
   });
 
-  describe('起動設定', () => {
-    it('「ログイン時に自動で起動する」のチェックボックスをクリックされた時にコールバック関数が呼ばれる', async () => {
+  describe('Launch settings', () => {
+    it('Callback function is called when "Launch automatically at login" checkbox is clicked', async () => {
       renderSettingContainer();
 
-      const checkbox = screen.getByLabelText('ログイン時に自動で起動する');
+      const checkbox = screen.getByLabelText('Launch automatically at login');
       await user.click(checkbox);
 
       expect(updateAutoLaunchMock).toBeCalledWith(
@@ -105,8 +106,8 @@ describe('SettingsContainer', () => {
     });
   });
 
-  describe('リポジトリ一覧', () => {
-    it('監視しているリポジトリの一覧を表示する', async () => {
+  describe('Repository list', () => {
+    it('Displays the list of monitored repositories', async () => {
       renderSettingContainer();
 
       const repositories = defaultSettings.subscribedRepositories.map(
@@ -120,11 +121,11 @@ describe('SettingsContainer', () => {
       }
     });
 
-    it('削除アイコンをクリックした時にコールバック関数が呼ばれる', async () => {
+    it('Callback function is called when delete icon is clicked', async () => {
       renderSettingContainer();
 
       const deleteIcon = screen.getAllByRole('button', {
-        name: 'リポジトリを削除',
+        name: 'Delete repository',
       })[0];
       await user.click(deleteIcon);
 

--- a/packages/web/src/hooks/useGItHubAccounts.spec.tsx
+++ b/packages/web/src/hooks/useGItHubAccounts.spec.tsx
@@ -37,7 +37,7 @@ const graphQLMocks: MockedProviderProps['mocks'] = [
 ];
 
 describe('useGitHubAccounts', () => {
-  it('ログイン中のユーザーアカウントを一覧に含める', async () => {
+  it('Includes the logged-in user account in the list', async () => {
     const wrapper = ({ children }: { children: ReactNode }) => (
       <MockedProvider mocks={graphQLMocks}>{children}</MockedProvider>
     );
@@ -50,7 +50,7 @@ describe('useGitHubAccounts', () => {
     });
   });
 
-  it('ログイン中のユーザーが所属する組織アカウントを一覧に含める', async () => {
+  it('Includes organization accounts the logged-in user belongs to in the list', async () => {
     const wrapper = ({ children }: { children: ReactNode }) => (
       <MockedProvider mocks={graphQLMocks}>{children}</MockedProvider>
     );

--- a/packages/web/src/lib/notification.spec.ts
+++ b/packages/web/src/lib/notification.spec.ts
@@ -18,12 +18,12 @@ describe('lib/notification', () => {
     window.Notification = NotificationOriginal;
   });
 
-  describe('自分がレビュアーのプルリクエストの場合', () => {
+  describe('When the logged-in user is a reviewer of the pull request', () => {
     const loginUser = createUser({ name: 'notification-test' });
 
-    it('新しい「レビュー待ち」のプルリクエストが存在したらデスクトップ通知をする', () => {
+    it('Send desktop notification when a new "waiting for review" pull request exists', () => {
       const newPullRequest = createPullRequest({
-        title: '新しいPR',
+        title: 'New PR',
         url: 'https://github.com/higeOhige/review-cat/pull/100',
         status: pullRequestStatus.waitingReview,
       });
@@ -41,7 +41,7 @@ describe('lib/notification', () => {
       );
     });
 
-    it('更新後のプルリクエストが「レビュー待ち」に更新された時にデスクトップ通知をする', () => {
+    it('Send desktop notification when the updated pull request changes to "waiting for review"', () => {
       const pullRequest = createPullRequest();
       const newPullRequests: PullRequest[] = [
         { ...pullRequest, status: pullRequestStatus.waitingReview },
@@ -59,7 +59,7 @@ describe('lib/notification', () => {
       );
     });
 
-    it('更新後のプルリクエストが「レビュー済み」の場合はデスクトップ通知をしない', () => {
+    it('Do not send desktop notification when the updated pull request is "reviewed"', () => {
       const pullRequest = createPullRequest();
       const newPullRequests: PullRequest[] = [
         { ...pullRequest, status: pullRequestStatus.approved },
@@ -73,13 +73,13 @@ describe('lib/notification', () => {
     });
   });
 
-  describe('自分が作成したプルリクエストの場合', () => {
+  describe('When the pull request is created by self', () => {
     const loginUser = createUser({ name: 'notification-test' });
     const pullRequest = createPullRequest({
       author: loginUser,
     });
 
-    it('更新後のプルリクエストが「レビュー済み」になった時にデスクトップ通知する', () => {
+    it('Send desktop notification when the updated pull request becomes "reviewed"', () => {
       const newPullRequests: PullRequest[] = [
         { ...pullRequest, status: pullRequestStatus.reviewed },
       ];
@@ -91,7 +91,7 @@ describe('lib/notification', () => {
       expect(NotificationMock).toBeCalled();
     });
 
-    it('更新前後で「レビュー済み」のままの場合はデスクトップ通知をしない', () => {
+    it('Do not send desktop notification if the status remains "reviewed" before and after update', () => {
       const newPullRequests: PullRequest[] = [
         { ...pullRequest, status: pullRequestStatus.reviewed },
       ];

--- a/packages/web/src/lib/notification.ts
+++ b/packages/web/src/lib/notification.ts
@@ -5,29 +5,29 @@ const shouldNotify = (
   newPullRequest: PullRequest,
   beforePullRequest?: PullRequest
 ) => {
-  // プルリクエストのステータスが変更されていない場合は通知しない
+  // Do not notify if the pull request status has not changed
   if (beforePullRequest?.status === newPullRequest.status) {
     return false;
   }
 
-  // 自分が作成したプルリクエストの場合はレビュー済みになった状態で通知する
+  // For pull requests created by self, notify when the status becomes reviewed
   if (newPullRequest.author.name === loginUser.name) {
     return newPullRequest.status === pullRequestStatus.reviewed;
   }
 
-  // 自分がレビュアーのプルリクエストの場合
+  // For pull requests where self is the reviewer
   return newPullRequest.status === pullRequestStatus.waitingReview;
 };
 
 /**
- * デスクトップ通知をする
- * NOTE: ElectronではレンダラープロセスでHTML5のNotification APIを利用すると
- *       プラットフォームのネイティブ通知が実行される。
- *       許可などの管理もプラットフォームに依存するので、コード上での許可の確認は不要
+ * Send desktop notification
+ * NOTE: In Electron, using the HTML5 Notification API in the renderer process
+ *       executes a platform native notification.
+ *       Permission management depends on the platform, so no need to check permissions in code
  * @param pullRequest
  */
 const notifyPullRequest = (pullRequest: PullRequest) => {
-  new Notification('新着のレビューリクエスト', {
+  new Notification('New review request', {
     body: `${pullRequest.title}\n${pullRequest.url}`,
     requireInteraction: true,
   });

--- a/packages/web/src/lib/queryBuilder.spec.ts
+++ b/packages/web/src/lib/queryBuilder.spec.ts
@@ -2,14 +2,14 @@ import { buildSearchPullRequestsQuery } from './queryBuilder';
 
 describe('queryBuilder', () => {
   describe('buildSearchPullRequestsQuery', () => {
-    it('リポジトリの一覧を含めた検索クエリが生成されること', () => {
+    it('A search query including the repository list is generated', () => {
       const repositories = ['test/repositoryA', 'test/repositoryB'];
       const result = buildSearchPullRequestsQuery(repositories);
       expect(result).toEqual(expect.stringContaining('repo:test/repositoryA'));
       expect(result).toEqual(expect.stringContaining('repo:test/repositoryB'));
     });
 
-    it('リポジトリの一覧が空配列の時は空文字を返す', () => {
+    it('Returns an empty string when the repository list is an empty array', () => {
       const repositories: string[] = [];
       const result = buildSearchPullRequestsQuery(repositories);
       expect(result).toBe('');

--- a/packages/web/src/lib/storage.spec.ts
+++ b/packages/web/src/lib/storage.spec.ts
@@ -40,7 +40,7 @@ describe('lib/storage', () => {
 
   describe('GithubAccessToken', () => {
     describe('getGithubAccessToken', () => {
-      it('localStorageからアクセストークンが取得できること', () => {
+      it('Can retrieve the access token from localStorage', () => {
         const token = 'token';
         mockLocalStorageGetItem('gh_atk', token);
 
@@ -50,7 +50,7 @@ describe('lib/storage', () => {
     });
 
     describe('setGithubAccessToken', () => {
-      it('localStorageにアクセストークンがセットできること', () => {
+      it('Can set the access token in localStorage', () => {
         const token = 'token';
         const mockSetItem = mockLocalStorageSetItem();
 
@@ -72,13 +72,13 @@ describe('lib/storage', () => {
     };
 
     describe('getSettings', () => {
-      it('localStorageから設定情報が取得できること', () => {
+      it('Can retrieve settings from localStorage', () => {
         mockLocalStorageGetItem('settings', JSON.stringify(settings));
         const result = storage.getSettings();
         expect(result).toEqual(settings);
       });
 
-      it('値が存在しないときに null を返すこと', () => {
+      it('Returns null when no value exists', () => {
         mockLocalStorageGetItem('settings', null);
         const result = storage.getSettings();
         expect(result).toBeNull();
@@ -86,13 +86,13 @@ describe('lib/storage', () => {
     });
 
     describe('setSettings', () => {
-      it('localStorageに設定情報をセットできること', () => {
+      it('Can set settings in localStorage', () => {
         const mockSetItem = mockLocalStorageSetItem();
 
         storage.setSettings(settings);
         expect(mockSetItem).toBeCalledWith(
           'settings',
-          JSON.stringify(settings) // NOTE: stringifyは順番が保証されないのでテストがコケる可能性があります。
+          JSON.stringify(settings) // NOTE: stringify does not guarantee order, so tests may fail.
         );
       });
     });

--- a/packages/web/src/pages/SelectRepositoryPage/SelectRepositoryPage.tsx
+++ b/packages/web/src/pages/SelectRepositoryPage/SelectRepositoryPage.tsx
@@ -12,7 +12,7 @@ export const SelectRepositoryPage = () => {
 
   const handleClick = useCallback(() => {
     if (setting.subscribedRepositories.length === 0) {
-      alert('レビュー対象のリポジトリを1つ以上選択してください。');
+      alert('Please select at least one repository to review.');
     } else {
       navigate('/', { replace: true });
     }
@@ -21,10 +21,10 @@ export const SelectRepositoryPage = () => {
   return (
     <BaseLayout>
       <div className={containerStyle}>
-        <h1 className={titleStyle}>リポジトリを選択</h1>
+        <h1 className={titleStyle}>Select Repository</h1>
         <SelectRepositoryContainer />
         <Button className={completeButtonStyle} onClick={handleClick}>
-          完了
+          Done
         </Button>
       </div>
     </BaseLayout>

--- a/packages/web/src/pages/SettingsPage/SettingsPage.tsx
+++ b/packages/web/src/pages/SettingsPage/SettingsPage.tsx
@@ -13,7 +13,7 @@ export const SettingsPage = () => {
     <BaseLayout>
       <div className={rootStyle}>
         <div className={titleWrapperStyle}>
-          <h1 className={titleStyle}>設定</h1>
+          <h1 className={titleStyle}>Settings</h1>
         </div>
         <div className={contentStyle}>
           <SettingsContainer />

--- a/packages/web/src/stores/pullRequest/helper.spec.ts
+++ b/packages/web/src/stores/pullRequest/helper.spec.ts
@@ -18,7 +18,7 @@ describe('stores/pullRequest/helper', () => {
       mockPullRequest = mock<SearchPullRequestFragment>();
     });
 
-    it('requestedReviewer に自分が含まれているときにプルリクエストをレビュー待ちの状態にする', () => {
+    it('Sets the pull request to waiting for review status when self is included in requestedReviewer', () => {
       when(mockPullRequest.reviewRequests).thenReturn({
         totalCount: 1,
         nodes: [
@@ -42,7 +42,7 @@ describe('stores/pullRequest/helper', () => {
       expect(status).toBe(pullRequestStatus.waitingReview);
     });
 
-    it('自身の承認済みのレビューが存在するときに対象のプルリクエストを承認済みにする', () => {
+    it('Marks the target pull request as approved when an approved review from self exists', () => {
       when(mockPullRequest.reviews).thenReturn({
         nodes: [
           {
@@ -62,7 +62,7 @@ describe('stores/pullRequest/helper', () => {
       expect(status).toBe(pullRequestStatus.approved);
     });
 
-    it('上記以外の場合はプルリクエストをレビュー済みの状態にする', () => {
+    it('Sets the pull request to reviewed status in all other cases', () => {
       when(mockPullRequest.reviews).thenReturn({
         nodes: [],
       });

--- a/packages/web/src/stores/pullRequest/helper.ts
+++ b/packages/web/src/stores/pullRequest/helper.ts
@@ -5,12 +5,12 @@ import {
 } from '@/gql/generated';
 
 /**
- * プルリクエストのステータス文字列を生成する
+ * Generate pull request status string
  *
- * ステータス:
- *   requestedReview(レビュー待ち): requestedReviewer に自分が含まれている
- *   approved(承認済み): 自分の state: APPROVED のレビューが存在する
- *   reviewed(レビュー済み): 上記以外のプルリクエスト
+ * Status:
+ *   requestedReview(waiting for review): self is included in requestedReviewer
+ *   approved: a review with own state: APPROVED exists
+ *   reviewed: pull requests other than the above
  */
 export const getPullRequestStatus = (
   pr: SearchPullRequestFragment,
@@ -34,14 +34,14 @@ export const getPullRequestStatus = (
       ?.filter((n) => n?.state === 'APPROVED')
       .map((n) => n?.author?.login) ?? [];
 
-  // PRのオーナーが自分の場合のプルリクのステータス
+  // Pull request status when the PR owner is self
   if (pr.author?.login === loginUser.name) {
-    // approvedしているユーザーがレビュアーに含まれていない
+    // User who has approved is not included in reviewers
     const approved =
       approvedReviewAuthors.some(
         (approvedAuthor) => !reviewers.includes(approvedAuthor)
       ) || pr.reviewDecision === 'APPROVED';
-    // レビューリクエストに全てのレビュアーが含まれていたらレビュー待ちと判定
+    // If all reviewers are in the review request, determine as waiting for review
     if (reviewRequestedAuthors.length === reviewers.length) {
       return pullRequestStatus.waitingReview;
     } else if (approved) {
@@ -50,13 +50,13 @@ export const getPullRequestStatus = (
       return pullRequestStatus.reviewed;
     }
   }
-  // PRのオーナーが自分以外の場合のプルリクのステータス
+  // Pull request status when the PR owner is someone else
   else {
-    // reviewRequests に自分が含まれている場合はレビュー待ちと判定
+    // If self is in reviewRequests, determine as waiting for review
     if (reviewRequestedAuthors.includes(loginUser.name)) {
       return pullRequestStatus.waitingReview;
     }
-    // 自分が承認済みのレビューがある場合は承認済みと判定
+    // If there is an approved review from self, determine as approved
     else if (approvedReviewAuthors.includes(loginUser.name)) {
       return pullRequestStatus.approved;
     } else {

--- a/packages/web/src/stores/pullRequest/useWatchPullRequests.ts
+++ b/packages/web/src/stores/pullRequest/useWatchPullRequests.ts
@@ -12,7 +12,7 @@ import {
   SearchPullRequestsQueryVariables,
 } from '@/gql/generated';
 
-// 頻度が多いと Github GraphQL API のレート制限に影響するので、投げるクエリのスコアを計算して調整してください。
+// High frequency affects the rate limit of the Github GraphQL API, so calculate the score of the query being sent and adjust accordingly.
 // @see: https://docs.github.com/ja/graphql/overview/resource-limitations
 const FETCH_PULL_REQUESTS_INTERVAL = 60 * 1000; // ms
 

--- a/packages/web/src/stores/setting/setting.spec.ts
+++ b/packages/web/src/stores/setting/setting.spec.ts
@@ -13,7 +13,7 @@ describe('stores/setting', () => {
     jest.clearAllMocks();
   });
 
-  it('設定情報を更新する時にストレージに更新後の設定情報が保存される', () => {
+  it('When updating settings, the updated settings are saved to storage', () => {
     const { result } = customRenderHook(() => useRecoilState(settingState));
 
     const updated: Settings = {

--- a/packages/web/src/stores/setting/useSetting.spec.tsx
+++ b/packages/web/src/stores/setting/useSetting.spec.tsx
@@ -16,15 +16,15 @@ describe('useSetting', () => {
     return customRenderHook(() => useSetting());
   };
 
-  describe('設定情報の読み込み', () => {
-    it('ストレージに設定情報が存在しないときにデフォルトの値を初期値として返す', () => {
+  describe('Loading settings', () => {
+    it('Returns default value as initial value when no settings exist in storage', () => {
       mockStorage.getSettings.mockReturnValue(null);
       const { result } = renderUseSetting();
 
       expect(result.current.setting).not.toBeNull();
     });
 
-    it('ストレージから設定情報を読み込む', () => {
+    it('Loads settings from storage', () => {
       const savedSettings: Settings = {
         notifyReviewRequested: true,
         showsRequestedReviewPR: true,
@@ -42,8 +42,8 @@ describe('useSetting', () => {
     });
   });
 
-  describe('設定情報の保存', () => {
-    it('レビューリクエストの通知設定を更新する', () => {
+  describe('Saving settings', () => {
+    it('Updates notification settings for review requests', () => {
       const { result } = renderUseSetting();
 
       const updated = !result.current.setting.notifyReviewRequested;
@@ -54,7 +54,7 @@ describe('useSetting', () => {
       expect(result.current.setting.notifyReviewRequested).toBe(updated);
     });
 
-    it('PRの表示設定を更新する', () => {
+    it('Updates PR display settings', () => {
       const { result } = renderUseSetting();
       const setting = result.current.setting;
 
@@ -76,7 +76,7 @@ describe('useSetting', () => {
       expect(result.current.setting.showsApprovedPR).toBe(updatedApproved);
     });
 
-    it('自動起動設定を更新する', () => {
+    it('Updates auto-launch setting', () => {
       window.ipc = {
         updateAutoLaunch: jest.fn(),
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -93,7 +93,7 @@ describe('useSetting', () => {
       expect(window.ipc.updateAutoLaunch).toBeCalledWith(!updateValue);
     });
 
-    it('PRを監視するリポジトリを追加する', () => {
+    it('Adds repository to monitor for PRs', () => {
       const { result } = renderUseSetting();
 
       const repositories = ['test/test1', 'test/test2'];
@@ -109,7 +109,7 @@ describe('useSetting', () => {
       );
     });
 
-    it('PRを監視するリポジトリを削除する', () => {
+    it('Removes repository from PR monitoring', () => {
       const { result } = renderUseSetting();
 
       const repositories = ['test/test1', 'test/test2'];

--- a/packages/web/src/themeStyleHelper.spec.ts
+++ b/packages/web/src/themeStyleHelper.spec.ts
@@ -1,7 +1,7 @@
 import { space } from './themeStyleHelper';
 
 describe('space', () => {
-  test('倍数を指定できる', () => {
+  test('Can specify a multiplier', () => {
     expect(space(1)).toBe('8px');
     expect(space(2)).toBe('16px');
     expect(space(10)).toBe('80px');

--- a/packages/web/test/mocks/factory/pullRequest.ts
+++ b/packages/web/test/mocks/factory/pullRequest.ts
@@ -4,7 +4,7 @@ import { PullRequest, pullRequestStatus } from '../../../src/models';
 
 export const createPullRequest = (pullRequest?: Partial<PullRequest>) => {
   const defaultValue: PullRequest = {
-    title: 'テストPRです',
+    title: 'Test PR',
     url: 'https://github.com/higeOhige/review-cat/pull/84',
     author: createUser(),
     repository: createRepository(),


### PR DESCRIPTION
## Summary

- Translate Japanese comments, UI strings, aria-labels, and test descriptions to English across the codebase
- Covers e2e tests, components, stores, hooks, and utility libraries
- No logic changes — purely a translation of human-readable text

## Files Changed

- `packages/e2e/playwright/` — test descriptions and helper comments
- `packages/main/` — build scripts and app-level comments
- `packages/web/src/` — component labels, aria-labels, store/helper comments, notification messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)