### PR TITLE
chore: add worktree management scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "test": "pnpm --filter web test && pnpm --filter main test && pnpm test:e2e",
     "test:e2e": "pnpm --filter e2e test",
     "test:coverage": "pnpm --filter web test --coverage && pnpm --filter main test --coverage",
-    "type-check": "pnpm --filter web type-check && pnpm --filter main type-check"
+    "type-check": "pnpm --filter web type-check && pnpm --filter main type-check",
+    "worktree:new": "bash scripts/new-worktree.sh",
+    "worktree:remove": "bash scripts/remove-worktree.sh"
   },
   "devDependencies": {
     "@review-cat/eslint-config-custom": "workspace:*",

--- a/scripts/new-worktree.sh
+++ b/scripts/new-worktree.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+BRANCH=$1
+BASE=${2:-main}
+REPO_ROOT=$(git rev-parse --show-toplevel)
+DIR="$(dirname "$REPO_ROOT")/review-cat-$(echo $BRANCH | sed 's/\//-/g')"
+
+git worktree add -b "$BRANCH" "$DIR" "origin/$BASE"
+
+find "$REPO_ROOT" -name ".env*" -not -path "*/.git/*" -not -path "*/node_modules/*" | while read -r env_file; do
+  relative="${env_file#$REPO_ROOT/}"
+  dest="$DIR/$relative"
+  mkdir -p "$(dirname "$dest")"
+  cp "$env_file" "$dest"
+done
+
+pnpm --dir "$DIR" install
+
+echo "Worktree ready: $DIR"

--- a/scripts/remove-worktree.sh
+++ b/scripts/remove-worktree.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+if ! command -v peco &> /dev/null; then
+  echo "Error: peco is not installed. Run: brew install peco"
+  exit 1
+fi
+
+# Prune prunable worktrees before showing list
+git worktree prune
+
+# Choose worktree with peco without main worktree
+SELECTED=$(git worktree list \
+  | tail -n +2 \
+  | peco --prompt "Select worktree to remove > ")
+
+if [ -z "$SELECTED" ]; then
+  echo "No worktree selected."
+  exit 0
+fi
+
+DIR=$(echo "$SELECTED" | awk '{print $1}')
+BRANCH=$(echo "$SELECTED" | grep -o '\[.*\]' | tr -d '[]')
+
+echo "Removing worktree: $DIR"
+if ! git worktree remove "$DIR" 2>/dev/null; then
+  echo "Warning: '$DIR' contains modified or untracked files."
+  read -rp "Force remove? [y/N] " answer
+  if [[ "$answer" =~ ^[Yy]$ ]]; then
+    git worktree remove --force "$DIR"
+  else
+    echo "Aborted. $DIR is not removed."
+    exit 1
+  fi
+fi
+
+echo "Deleting branch: $BRANCH"
+git branch -D "$BRANCH"
+
+echo "Done."


### PR DESCRIPTION
## Summary

- Add `scripts/new-worktree.sh` to create a new git worktree with a specified branch, copy `.env` files, and run `pnpm install`
- Add `scripts/remove-worktree.sh` to interactively select and remove a worktree (and its branch) using `peco`
- Register both scripts as `worktree:new` and `worktree:remove` npm scripts in `package.json`

## Test plan

- [ ] Run `pnpm worktree:new <branch-name>` and confirm worktree is created under `../review-cat-<branch-name>`, `.env` files are copied, and dependencies are installed
- [ ] Run `pnpm worktree:remove`, select a worktree via peco, and confirm the worktree directory and branch are removed
- [ ] Confirm force-remove prompt appears when the worktree has untracked/modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)