### PR TITLE
fix: improve focus border style for RepositorySearchBox

### DIFF
--- a/packages/web/src/components/RepositorySearchBox/style.css.ts
+++ b/packages/web/src/components/RepositorySearchBox/style.css.ts
@@ -10,6 +10,11 @@ export const rootStyle = style({
   display: 'flex',
   alignItems: 'center',
   fontSize: '1.2rem',
+  selectors: {
+    '&:focus-within': {
+      outline: '2px solid rgba(0, 110, 255, 0.8)',
+    },
+  },
 });
 
 export const iconStyle = style({
@@ -20,5 +25,8 @@ export const inputStyle = style({
   paddingLeft: space(1),
   '::placeholder': {
     color: themeVars.color.gray300,
+  },
+  ':focus': {
+    outline: 'none',
   },
 });


### PR DESCRIPTION
## Summary

- Add `focus-within` outline on the search box container to show a blue border when the input is focused
- Remove the default browser focus outline from the input itself to prevent double outlines

🤖 Generated with [Claude Code](https://claude.com/claude-code)