### PR TITLE
Use HashRouter instead of BrowserRouter

### DIFF
--- a/packages/web/src/components/routes/AppRoute/AppRoute.tsx
+++ b/packages/web/src/components/routes/AppRoute/AppRoute.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route, BrowserRouter, Navigate } from 'react-router-dom';
+import { Routes, Route, HashRouter, Navigate } from 'react-router-dom';
 import { useSetting } from '@/stores';
 import { LoginPage, PullRequestListPage, SelectRepositoryPage } from '@/pages';
 import { SettingsPage } from '@/pages/SettingsPage';
@@ -8,7 +8,7 @@ export const AppRoute = () => {
   const { setting } = useSetting();
 
   return (
-    <BrowserRouter
+    <HashRouter
       future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
     >
       <Routes>
@@ -42,6 +42,6 @@ export const AppRoute = () => {
           }
         />
       </Routes>
-    </BrowserRouter>
+    </HashRouter>
   );
 };


### PR DESCRIPTION
## 概要

`AppRoute` のルーターを `BrowserRouter` から `HashRouter` に変更します。

## 変更内容

- `packages/web/src/components/routes/AppRoute/AppRoute.tsx` で `BrowserRouter` を `HashRouter` に置き換え

## 背景

Electron のようにファイルプロトコル / 静的ホスティング環境で読み込む場合、`BrowserRouter` ではパスベースのルーティングがサーバー設定に依存し正しく解決されないことがあります。`HashRouter` を使うことでハッシュベースのルーティングとなり、そうした環境でもリロードや直接アクセスが安定して動作します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)